### PR TITLE
Track daily review streak on dashboard (#31)

### DIFF
--- a/__tests__/api/stats-streak.test.ts
+++ b/__tests__/api/stats-streak.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/stats/streak/route'
+
+type Row = Record<string, unknown>
+
+const USER = '00000000-0000-0000-0000-000000000001'
+
+function makeMockDb(reviewLogs: Row[] = []) {
+  return {
+    from: (table: string) => {
+      if (table === 'review_log') {
+        return {
+          select: (_cols: string) => ({
+            eq: (_col: string, _val: unknown) =>
+              Promise.resolve({ data: reviewLogs, error: null }),
+          }),
+        }
+      }
+      return {}
+    },
+  }
+}
+
+describe('GET /api/stats/streak', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const db = makeMockDb()
+    const req = new Request('http://localhost/api/stats/streak')
+    const response = await GET(req, { db: db as never, authFn: async () => null })
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 0 when the user has no reviews', async () => {
+    const db = makeMockDb([])
+    const req = new Request('http://localhost/api/stats/streak')
+    const response = await GET(req, {
+      db: db as never,
+      authFn: async () => ({ id: USER }),
+      now: () => new Date('2026-04-20T12:00:00Z'),
+    })
+    const body = await response.json()
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ streak: 0 })
+  })
+
+  it('returns the correct streak from review_log rows', async () => {
+    const reviewLogs: Row[] = [
+      { reviewed_at: '2026-04-20T09:00:00Z' },
+      { reviewed_at: '2026-04-20T20:00:00Z' },
+      { reviewed_at: '2026-04-19T11:00:00Z' },
+      { reviewed_at: '2026-04-18T08:00:00Z' },
+      // gap at 2026-04-17
+      { reviewed_at: '2026-04-16T08:00:00Z' },
+    ]
+    const db = makeMockDb(reviewLogs)
+    const req = new Request('http://localhost/api/stats/streak')
+    const response = await GET(req, {
+      db: db as never,
+      authFn: async () => ({ id: USER }),
+      now: () => new Date('2026-04-20T12:00:00Z'),
+    })
+    const body = await response.json()
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ streak: 3 })
+  })
+})

--- a/__tests__/lib/streak.test.ts
+++ b/__tests__/lib/streak.test.ts
@@ -1,0 +1,62 @@
+import { computeStreak } from '@/lib/streak'
+
+const utcDate = (iso: string) => new Date(iso + 'T12:00:00Z')
+
+describe('computeStreak', () => {
+  it('returns 0 when there are no reviews', () => {
+    const now = utcDate('2026-04-20')
+    expect(computeStreak([], now)).toBe(0)
+  })
+
+  it('returns 1 when there is a review today', () => {
+    const now = utcDate('2026-04-20')
+    const reviews = [utcDate('2026-04-20')]
+    expect(computeStreak(reviews, now)).toBe(1)
+  })
+
+  it('returns 1 when the most recent review is yesterday (no review today yet)', () => {
+    const now = utcDate('2026-04-20')
+    const reviews = [utcDate('2026-04-19')]
+    expect(computeStreak(reviews, now)).toBe(1)
+  })
+
+  it('returns 0 when the most recent review was 2+ days ago', () => {
+    const now = utcDate('2026-04-20')
+    const reviews = [utcDate('2026-04-18'), utcDate('2026-04-17')]
+    expect(computeStreak(reviews, now)).toBe(0)
+  })
+
+  it('counts an unbroken 5-day run ending today', () => {
+    const now = utcDate('2026-04-20')
+    const reviews = [
+      utcDate('2026-04-20'),
+      utcDate('2026-04-19'),
+      utcDate('2026-04-18'),
+      utcDate('2026-04-17'),
+      utcDate('2026-04-16'),
+    ]
+    expect(computeStreak(reviews, now)).toBe(5)
+  })
+
+  it('stops counting at the first gap', () => {
+    const now = utcDate('2026-04-20')
+    const reviews = [
+      utcDate('2026-04-20'),
+      utcDate('2026-04-19'),
+      // gap: 2026-04-18 missing
+      utcDate('2026-04-17'),
+      utcDate('2026-04-16'),
+    ]
+    expect(computeStreak(reviews, now)).toBe(2)
+  })
+
+  it('de-duplicates multiple reviews on the same day', () => {
+    const now = utcDate('2026-04-20')
+    const reviews = [
+      new Date('2026-04-20T05:00:00Z'),
+      new Date('2026-04-20T15:00:00Z'),
+      new Date('2026-04-20T22:00:00Z'),
+    ]
+    expect(computeStreak(reviews, now)).toBe(1)
+  })
+})

--- a/app/api/stats/streak/route.ts
+++ b/app/api/stats/streak/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabase'
+import { getSessionUser } from '@/lib/supabase-server'
+import { computeStreak } from '@/lib/streak'
+
+interface StreakDeps {
+  db?: SupabaseClient
+  authFn?: () => Promise<{ id: string } | null>
+  now?: () => Date
+}
+
+export async function GET(_req: Request, deps: StreakDeps = {}) {
+  const db = deps.db ?? supabase
+  const authFn = deps.authFn ?? getSessionUser
+  const now = deps.now ?? (() => new Date())
+
+  const user = await authFn()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data, error } = await db
+    .from('review_log')
+    .select('reviewed_at')
+    .eq('user_id', user.id)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const dates = (data ?? []).map((row: { reviewed_at: string }) => new Date(row.reviewed_at))
+  const streak = computeStreak(dates, now())
+
+  return NextResponse.json({ streak })
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -47,6 +47,7 @@ export default function DashboardPage() {
   const [counts, setCounts] = useState<ModeCounts | null>(null)
   const [session, setSession] = useState<ReviewSession | null>(null)
   const [syncStatus, setSyncStatus] = useState<SyncLog | null | undefined>(undefined)
+  const [streak, setStreak] = useState<number | null>(null)
 
   useEffect(() => {
     fetch('/api/review/counts')
@@ -60,6 +61,13 @@ export default function DashboardPage() {
     fetch('/api/sync/status')
       .then((r) => r.json())
       .then(setSyncStatus)
+
+    fetch('/api/stats/streak')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data && typeof data.streak === 'number') setStreak(data.streak)
+      })
+      .catch(() => {})
   }, [])
 
   const dueToday = counts?.standard ?? null
@@ -146,7 +154,7 @@ export default function DashboardPage() {
         <section style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 36, padding: '40px 0', borderBottom: '1px solid var(--line)' }}>
           <Stat big={dueToday ?? '—'} label="Due today" mono />
           <Stat big={newCards ?? '—'} label="New cards" mono />
-          <Stat big="—" label="Day streak" mono sub="Not tracked yet" />
+          <Stat big={streak ?? '—'} label="Day streak" mono />
           <Stat big="—" label="7-day accuracy" mono sub="Not tracked yet" />
           <Stat big={counts ? Object.values(counts).reduce((a, b) => a + b, 0) : '—'} label="Total in deck" mono />
         </section>

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -1,0 +1,23 @@
+function toUtcDayStart(d: Date): number {
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export function computeStreak(reviewDates: Date[], now: Date): number {
+  const days = new Set(reviewDates.map(toUtcDayStart))
+  const today = toUtcDayStart(now)
+  const yesterday = today - DAY_MS
+
+  let cursor: number
+  if (days.has(today)) cursor = today
+  else if (days.has(yesterday)) cursor = yesterday
+  else return 0
+
+  let streak = 0
+  while (days.has(cursor)) {
+    streak += 1
+    cursor -= DAY_MS
+  }
+  return streak
+}

--- a/plans/chess-improver.md
+++ b/plans/chess-improver.md
@@ -536,6 +536,30 @@ Order of execution is not fixed — pick them up based on priority. Issues #28, 
 
 ---
 
+### Mini-plan: Issue #31 — Track daily review streak
+
+**What the user will see change.** The dashboard's "Day streak" tile (currently `—` with "Not tracked yet") shows a number: the count of consecutive days the user has reviewed at least one card, counting today. If the user hasn't reviewed today yet but did review yesterday, the streak still shows — a streak only breaks once a full day is skipped. No reviews at all, or most recent review 2+ days ago, shows `0`.
+
+**Database changes.** None. Every review already writes a row to `review_log` with a `reviewed_at` timestamp. Consecutive-day counting runs over those rows.
+
+**API changes.** One new route: `GET /api/stats/streak`. Auth-scoped. Returns `{ streak: number }`. Logic: collect distinct UTC days from the user's `review_log` rows, start at today (or yesterday if today has none), then walk backwards day-by-day counting while each previous day is present; stop at the first gap.
+
+**UI changes.** Dashboard stats strip "Day streak" tile fetches `/api/stats/streak` on load and renders the number. Falls back to `—` if the fetch fails. The "Not tracked yet" subtitle is removed.
+
+**Acceptance criteria.**
+- [x] `GET /api/stats/streak` returns `{ streak: N }` for the authenticated user
+- [x] Unauthenticated requests return 401
+- [x] Streak is `0` when the user has never reviewed a card
+- [x] Streak counts today if there's a review today
+- [x] Streak counts yesterday as the end if there's no review today but there is yesterday
+- [x] Streak is `0` if the most recent review was 2+ days ago
+- [x] Consecutive-day counting stops at the first gap
+- [x] Dashboard "Day streak" tile shows the value from the new endpoint instead of `—`
+- [x] Unit tests cover: no reviews, today only, yesterday only, 5-day unbroken run, run broken by a gap, multiple reviews on the same day
+- [x] Integration test: mocked `review_log` rows produce the expected streak via the API
+
+---
+
 ## Phase 21: Move Explanations (V2 Enhancement)
 
 **User stories**: TBD


### PR DESCRIPTION
## Summary
- New `GET /api/stats/streak` returns `{ streak: N }` — consecutive-day streak over the user's `review_log`
- Dashboard "Day streak" tile now shows the real number instead of `—`
- No schema changes (derived from existing `review_log.reviewed_at`)

Closes #31.

## Behaviour
- `0` when the user has never reviewed, or most recent review was 2+ days ago
- Counts today if there's a review today
- Counts yesterday as the end if today has none yet (streak doesn't break mid-day)
- Stops at the first gap in consecutive days

## Test plan
- [x] Unit tests for `computeStreak` — empty, today only, yesterday only, stale, 5-day run, gap, same-day dedupe
- [x] API tests — 401, empty, happy-path with mocked `review_log`
- [x] Dashboard tile reads from the new endpoint
- [x] Full suite: no new test failures vs. `origin/main` baseline
- [ ] Manual smoke: dashboard shows the streak value after a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)