### PR TITLE
Surface DB errors when saving chess.com username in onboarding

### DIFF
--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -122,8 +122,18 @@ function LinkStep({ onNext }: { onNext: (username: string) => void }) {
         // Save to DB
         const supabase = createClient()
         const { data: { user } } = await supabase.auth.getUser()
-        if (user) {
-          await supabase.from('users').upsert({ id: user.id, chess_com_username: username.trim() })
+        if (!user) {
+          setVerifyError('Not signed in. Please log in again and retry.')
+          setVerifying(false)
+          return
+        }
+        const { error: saveError } = await supabase
+          .from('users')
+          .upsert({ id: user.id, email: user.email, chess_com_username: username.trim() })
+        if (saveError) {
+          setVerifyError(`Could not save username: ${saveError.message}`)
+          setVerifying(false)
+          return
         }
         setVerified(true)
       } else {


### PR DESCRIPTION
## Summary
- `LinkStep` silently swallowed Supabase upsert errors, so users saw "✓ Verified" even when the DB write failed — then got a confusing 422 ("Chess.com username not set") at the import step.
- Now surfaces the error inline and also includes `email` in the upsert payload (the users table has NOT NULL on email; if the upsert ever hits the INSERT path without it, the write fails).

## Test plan
- [ ] Manual: sign up → step 2 → enter a valid chess.com handle → "Verify" should succeed quickly and show green
- [ ] Manual: if save fails (e.g. no session), the error text appears under the field rather than silently advancing