### PR TITLE
Add Connected accounts section to settings page

### DIFF
--- a/__tests__/api/user-settings.test.ts
+++ b/__tests__/api/user-settings.test.ts
@@ -20,26 +20,42 @@ function makeGetRequest() {
 }
 
 describe('GET /api/user/settings', () => {
-  it("returns the current user's settings including name fields", async () => {
+  it("returns the current user's settings including name and chess.com fields", async () => {
     const { db } = makeMockDb({
-      users: [{ id: USER, daily_new_limit: 15, first_name: 'Ada', last_name: 'Lovelace' }],
+      users: [{
+        id: USER,
+        daily_new_limit: 15,
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        chess_com_username: 'ada_plays',
+      }],
     })
 
     const response = await GET(makeGetRequest(), { db, authFn: async () => ({ id: USER }) })
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body).toEqual({ daily_new_limit: 15, first_name: 'Ada', last_name: 'Lovelace' })
+    expect(body).toEqual({
+      daily_new_limit: 15,
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      chess_com_username: 'ada_plays',
+    })
   })
 
-  it('defaults daily_new_limit to 10 and names to null when no row exists', async () => {
+  it('defaults daily_new_limit to 10 and other fields to null when no row exists', async () => {
     const { db } = makeMockDb({ users: [] })
 
     const response = await GET(makeGetRequest(), { db, authFn: async () => ({ id: USER }) })
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body).toEqual({ daily_new_limit: 10, first_name: null, last_name: null })
+    expect(body).toEqual({
+      daily_new_limit: 10,
+      first_name: null,
+      last_name: null,
+      chess_com_username: null,
+    })
   })
 })
 
@@ -162,5 +178,83 @@ describe('PATCH /api/user/settings', () => {
         filters: [{ op: 'eq', col: 'id', val: USER }],
       },
     ])
+  })
+
+  describe('chess_com_username', () => {
+    it('updates chess_com_username, trimming whitespace', async () => {
+      const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+      const response = await PATCH(makeRequest({ chess_com_username: '  ada_plays  ' }), {
+        db,
+        authFn: async () => ({ id: USER }),
+      })
+
+      expect(response.status).toBe(200)
+      expect(updated.users).toEqual([
+        {
+          values: { chess_com_username: 'ada_plays' },
+          filters: [{ op: 'eq', col: 'id', val: USER }],
+        },
+      ])
+    })
+
+    it('returns 400 when chess_com_username is an empty string', async () => {
+      const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+      const response = await PATCH(makeRequest({ chess_com_username: '' }), {
+        db,
+        authFn: async () => ({ id: USER }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(updated.users ?? []).toHaveLength(0)
+    })
+
+    it('returns 400 when chess_com_username is whitespace-only', async () => {
+      const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+      const response = await PATCH(makeRequest({ chess_com_username: '   ' }), {
+        db,
+        authFn: async () => ({ id: USER }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(updated.users ?? []).toHaveLength(0)
+    })
+
+    it('returns 400 when chess_com_username is too long', async () => {
+      const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+      const response = await PATCH(makeRequest({ chess_com_username: 'a'.repeat(51) }), {
+        db,
+        authFn: async () => ({ id: USER }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(updated.users ?? []).toHaveLength(0)
+    })
+
+    it('returns 400 when chess_com_username is not a string', async () => {
+      const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+      const response = await PATCH(makeRequest({ chess_com_username: 123 }), {
+        db,
+        authFn: async () => ({ id: USER }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(updated.users ?? []).toHaveLength(0)
+    })
+
+    it('returns 401 when updating chess_com_username without auth', async () => {
+      const { db } = makeMockDb({ users: [{ id: USER }] })
+
+      const response = await PATCH(makeRequest({ chess_com_username: 'ada_plays' }), {
+        db,
+        authFn: async () => null,
+      })
+
+      expect(response.status).toBe(401)
+    })
   })
 })

--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -14,11 +14,12 @@ type NextRouteContext = { params: Promise<Record<string, string | string[] | und
 const MIN_DAILY_NEW = 4
 const MAX_DAILY_NEW = 30
 const MAX_NAME_LEN = 60
+const MAX_CHESS_HANDLE_LEN = 50
 
 export const GET = withAuthedRoute(async ({ db, user }) => {
   const { data, error } = await db
     .from('users')
-    .select('daily_new_limit, first_name, last_name')
+    .select('daily_new_limit, first_name, last_name, chess_com_username')
     .eq('id', user.id)
     .single()
 
@@ -27,6 +28,7 @@ export const GET = withAuthedRoute(async ({ db, user }) => {
     daily_new_limit: data?.daily_new_limit ?? 10,
     first_name: data?.first_name ?? null,
     last_name: data?.last_name ?? null,
+    chess_com_username: data?.chess_com_username ?? null,
   })
 })
 
@@ -80,6 +82,24 @@ export async function PATCH(req: Request, deps: SettingsDeps | NextRouteContext)
     const r = validateName(raw.last_name)
     if (!r.ok) return NextResponse.json({ error: `last_name must be a string up to ${MAX_NAME_LEN} chars` }, { status: 400 })
     update.last_name = r.value
+  }
+
+  if ('chess_com_username' in raw) {
+    const h = raw.chess_com_username
+    if (typeof h !== 'string') {
+      return NextResponse.json({ error: 'chess_com_username must be a string' }, { status: 400 })
+    }
+    const trimmed = h.trim()
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: 'chess_com_username cannot be empty' }, { status: 400 })
+    }
+    if (trimmed.length > MAX_CHESS_HANDLE_LEN) {
+      return NextResponse.json(
+        { error: `chess_com_username must be at most ${MAX_CHESS_HANDLE_LEN} chars` },
+        { status: 400 },
+      )
+    }
+    update.chess_com_username = trimmed
   }
 
   if (Object.keys(update).length === 0) {

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Logo, Button, Field, Input } from '@/components/ui'
 import { createClient } from '@/lib/supabase-browser'
+import { useChessComVerify } from '@/hooks/use-chess-com-verify'
 
 const STAGE_LABEL: Record<string, string> = {
   queued:    'Queued — worker picking up the job',
@@ -94,9 +95,7 @@ function NameStep({ onDone }: { onDone: () => void }) {
 
 function LinkStep({ onNext }: { onNext: (username: string) => void }) {
   const [username, setUsername] = useState('')
-  const [verifying, setVerifying] = useState(false)
-  const [verified, setVerified] = useState(false)
-  const [verifyError, setVerifyError] = useState<string | null>(null)
+  const { verify: runVerify, verifying, verified, error: verifyError, reset } = useChessComVerify()
 
   // Pre-fill from DB if already set
   useEffect(() => {
@@ -113,26 +112,13 @@ function LinkStep({ onNext }: { onNext: (username: string) => void }) {
   }, [])
 
   async function verify() {
-    if (!username.trim()) return
-    setVerifying(true)
-    setVerifyError(null)
-    try {
-      const res = await fetch(`https://api.chess.com/pub/player/${username.trim().toLowerCase()}`)
-      if (res.ok) {
-        // Save to DB
-        const supabase = createClient()
-        const { data: { user } } = await supabase.auth.getUser()
-        if (user) {
-          await supabase.from('users').upsert({ id: user.id, chess_com_username: username.trim() })
-        }
-        setVerified(true)
-      } else {
-        setVerifyError('Username not found on Chess.com. Check the spelling and try again.')
-      }
-    } catch {
-      setVerifyError('Could not reach Chess.com. Check your connection.')
+    const result = await runVerify(username)
+    if (!result.ok || !result.handle) return
+    const supabase = createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (user) {
+      await supabase.from('users').upsert({ id: user.id, chess_com_username: result.handle })
     }
-    setVerifying(false)
   }
 
   return (
@@ -151,7 +137,7 @@ function LinkStep({ onNext }: { onNext: (username: string) => void }) {
             <div style={{ display: 'flex', gap: 8 }}>
               <Input
                 value={username}
-                onChange={(e) => { setUsername(e.target.value); setVerified(false) }}
+                onChange={(e) => { setUsername(e.target.value); reset() }}
                 style={{ flex: 1 }}
                 placeholder="your_handle"
               />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,12 +3,15 @@
 import { useEffect, useState } from 'react'
 import { Nav, Page, Button, Field, Input } from '@/components/ui'
 import { useUserSettings } from '@/hooks/dashboard'
+import { useChessComVerify } from '@/hooks/use-chess-com-verify'
 
 export default function SettingsPage() {
   const settings = useUserSettings()
   const [newPerDay, setNewPerDay] = useState<number | null>(null)
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
+  const [chessComUsername, setChessComUsername] = useState('')
+  const [initialChessComUsername, setInitialChessComUsername] = useState('')
   const [loaded, setLoaded] = useState(false)
   const [saving, setSaving] = useState(false)
   const [savingName, setSavingName] = useState(false)
@@ -22,6 +25,8 @@ export default function SettingsPage() {
       setNewPerDay(settings.data.daily_new_limit)
       setFirstName(settings.data.first_name ?? '')
       setLastName(settings.data.last_name ?? '')
+      setChessComUsername(settings.data.chess_com_username ?? '')
+      setInitialChessComUsername(settings.data.chess_com_username ?? '')
       setLoaded(true)
     }
   }, [settings.data, loaded])
@@ -116,6 +121,21 @@ export default function SettingsPage() {
               </div>
             </div>
 
+            <div style={{ marginTop: 48, padding: '32px 36px', border: '1px solid var(--line)', background: 'var(--bg-2)', maxWidth: 720 }}>
+              <div className="mono" style={{ color: 'var(--muted)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 18 }}>
+                Connected accounts
+              </div>
+
+              <ChessComProviderRow
+                initialUsername={initialChessComUsername}
+                username={chessComUsername}
+                setUsername={setChessComUsername}
+                onSaved={(saved) => setInitialChessComUsername(saved)}
+              />
+
+              <LichessProviderRow />
+            </div>
+
             {newPerDay !== null && (
               <div style={{ marginTop: 48, padding: '32px 36px', border: '1px solid var(--line)', background: 'var(--bg-2)', maxWidth: 720 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
@@ -156,5 +176,133 @@ export default function SettingsPage() {
         )}
       </Page>
     </>
+  )
+}
+
+function ProviderRow({
+  label,
+  children,
+  disabled,
+}: {
+  label: string
+  children: React.ReactNode
+  disabled?: boolean
+}) {
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '160px 1fr', gap: 24,
+      padding: '20px 0', borderTop: '1px solid var(--line)',
+      opacity: disabled ? 0.5 : 1,
+    }}>
+      <div className="mono" style={{
+        color: 'var(--ink)', fontSize: 12, letterSpacing: '0.06em',
+        textTransform: 'uppercase', alignSelf: 'center',
+      }}>
+        {label}
+      </div>
+      <div>{children}</div>
+    </div>
+  )
+}
+
+interface ChessComProviderRowProps {
+  initialUsername: string
+  username: string
+  setUsername: (v: string) => void
+  onSaved: (saved: string) => void
+}
+
+function ChessComProviderRow({ initialUsername, username, setUsername, onSaved }: ChessComProviderRowProps) {
+  const { verify, verifying, verified, error: verifyError, reset } = useChessComVerify()
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const trimmed = username.trim()
+  const dirty = trimmed !== initialUsername.trim()
+  const canSave = verified && dirty && !saving
+
+  async function handleVerify() {
+    setSaved(false)
+    setSaveError(null)
+    await verify(username)
+  }
+
+  async function handleSave() {
+    if (!canSave) return
+    setSaving(true)
+    setSaveError(null)
+    setSaved(false)
+    try {
+      const res = await fetch('/api/user/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chess_com_username: trimmed }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setSaveError(body.error ?? `Save failed (${res.status})`)
+      } else {
+        setSaved(true)
+        onSaved(trimmed)
+      }
+    } catch {
+      setSaveError('Network error — please try again.')
+    }
+    setSaving(false)
+  }
+
+  return (
+    <ProviderRow label="Chess.com">
+      <Field label="Username" hint="Case-insensitive. Verify it exists on Chess.com before saving.">
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Input
+            value={username}
+            onChange={(e) => {
+              setUsername(e.target.value)
+              reset()
+              setSaved(false)
+              setSaveError(null)
+            }}
+            style={{ flex: 1 }}
+            placeholder="your_handle"
+            maxLength={50}
+          />
+          <Button variant="secondary" onClick={handleVerify} disabled={verifying || verified || !trimmed}>
+            {verifying ? 'Checking…' : verified ? '✓ Verified' : 'Verify'}
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </Field>
+      <div style={{ marginTop: 4, minHeight: 16, display: 'flex', gap: 14, alignItems: 'center' }}>
+        {verifyError && (
+          <span className="mono" style={{ color: 'var(--bad)', fontSize: 11 }}>{verifyError}</span>
+        )}
+        {saveError && (
+          <span className="mono" style={{ color: 'var(--bad)', fontSize: 11 }}>{saveError}</span>
+        )}
+        {saved && (
+          <span className="mono" style={{ color: 'var(--good)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+            ✓ Saved
+          </span>
+        )}
+      </div>
+    </ProviderRow>
+  )
+}
+
+function LichessProviderRow() {
+  return (
+    <ProviderRow label="Lichess" disabled>
+      <Field label="Username" hint="Coming soon.">
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Input value="" disabled placeholder="Not yet supported" style={{ flex: 1 }} />
+          <Button variant="secondary" disabled>Verify</Button>
+          <Button disabled>Save</Button>
+        </div>
+      </Field>
+    </ProviderRow>
   )
 }

--- a/hooks/dashboard.ts
+++ b/hooks/dashboard.ts
@@ -100,15 +100,22 @@ function validateSyncHistory(raw: unknown): SyncLog[] | null {
 
 function validateUserSettings(
   raw: unknown,
-): { daily_new_limit: number; first_name: string | null; last_name: string | null } | null {
+): {
+  daily_new_limit: number
+  first_name: string | null
+  last_name: string | null
+  chess_com_username: string | null
+} | null {
   if (!isObj(raw) || typeof raw.daily_new_limit !== 'number') return null
-  const { first_name, last_name } = raw
+  const { first_name, last_name, chess_com_username } = raw
   if (first_name !== null && typeof first_name !== 'string') return null
   if (last_name !== null && typeof last_name !== 'string') return null
+  if (chess_com_username !== null && typeof chess_com_username !== 'string') return null
   return {
     daily_new_limit: raw.daily_new_limit,
     first_name: first_name as string | null,
     last_name: last_name as string | null,
+    chess_com_username: chess_com_username as string | null,
   }
 }
 
@@ -348,6 +355,7 @@ export function useUserSettings(): FetchResult<{
   daily_new_limit: number
   first_name: string | null
   last_name: string | null
+  chess_com_username: string | null
 }> {
   return useFetchJson('/api/user/settings', validateUserSettings)
 }

--- a/hooks/use-chess-com-verify.ts
+++ b/hooks/use-chess-com-verify.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+export interface VerifyResult {
+  ok: boolean
+  handle?: string
+  error?: string
+}
+
+export async function verifyChessComHandle(handle: string): Promise<VerifyResult> {
+  const trimmed = handle.trim()
+  if (!trimmed) return { ok: false, error: 'Enter a username first.' }
+  try {
+    const res = await fetch(`https://api.chess.com/pub/player/${trimmed.toLowerCase()}`)
+    if (res.ok) return { ok: true, handle: trimmed }
+    return { ok: false, error: 'Username not found on Chess.com. Check the spelling and try again.' }
+  } catch {
+    return { ok: false, error: 'Could not reach Chess.com. Check your connection.' }
+  }
+}
+
+export function useChessComVerify() {
+  const [verifying, setVerifying] = useState(false)
+  const [verified, setVerified] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const verify = useCallback(async (handle: string): Promise<VerifyResult> => {
+    setVerifying(true)
+    setError(null)
+    const result = await verifyChessComHandle(handle)
+    setVerifying(false)
+    if (result.ok) {
+      setVerified(true)
+    } else {
+      setVerified(false)
+      setError(result.error ?? 'Verification failed.')
+    }
+    return result
+  }, [])
+
+  const reset = useCallback(() => {
+    setVerified(false)
+    setError(null)
+  }, [])
+
+  return { verify, verifying, verified, error, reset }
+}


### PR DESCRIPTION
## Summary
- Settings page gets a **Connected accounts** section structured as a list of provider rows. V1 ships Chess.com with Verify → Save flow; Lichess is a disabled "coming soon" placeholder so the slot is visible.
- `PATCH /api/user/settings` accepts `chess_com_username` (trimmed, non-empty, max 50 chars), so users who skipped or silently failed the onboarding upsert can set/change their handle without editing Supabase directly.
- Verify logic extracted into `useChessComVerify` hook; onboarding `LinkStep` now consumes it, so onboarding and settings share one code path.

## Test plan
- [x] `__tests__/api/user-settings.test.ts` — added cases: valid update (trimmed), empty string rejection, whitespace-only rejection, too-long rejection, non-string rejection, unauthorized. GET tests updated to include `chess_com_username`.
- [x] Full jest suite passes (337 tests).
- [x] `npm run typecheck` — no new errors (2 pre-existing errors in `__tests__/pages/review-session.test.tsx` unrelated to this change).
- [ ] Manual: open `/settings`, change Chess.com handle, verify & save; reload and confirm persistence.
- [ ] Manual: walk through `/onboard` LinkStep end-to-end to confirm the shared hook refactor didn't regress onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)