### PR TITLE
Use session-bound Supabase client in /api/sync/start

### DIFF
--- a/app/api/sync/start/route.ts
+++ b/app/api/sync/start/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { supabase } from '@/lib/supabase'
-import { getSessionUserWithUsername } from '@/lib/supabase-server'
+import { createClient, getSessionUserWithUsername } from '@/lib/supabase-server'
 import { inngest as defaultInngest } from '@/lib/inngest/client'
 import { apiError } from '@/lib/api-response'
 
@@ -26,7 +25,7 @@ export async function POST(req: Request, deps: StartDeps | NextRouteContext): Pr
   const mode: 'historical' | 'incremental' =
     body.mode === 'historical' ? 'historical' : 'incremental'
 
-  const db = actualDeps.db ?? supabase
+  const db = actualDeps.db ?? (await createClient())
   const authFn = actualDeps.authFn ?? (() => getSessionUserWithUsername(db))
   const user = await authFn()
   if (!user) return apiError(401, 'Unauthorized')


### PR DESCRIPTION
## Summary
- Route was using a bare anon client with no cookies to read users.chess_com_username
- RLS returned no rows, so the server always thought the user had no chess.com handle and fired a 422 at Sync now
- Switch to the cookie-bound createClient() so auth.uid() works and RLS lets the read through

## Test plan
- [x] Existing sync-start tests pass
- [ ] Manual: Sync now on /sync actually starts an Inngest run instead of 422ing