### PR TITLE
Use session-bound Supabase client in withAuthedRoute default

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,12 @@
 import "@testing-library/jest-dom";
+
+// next/headers cookies() can only run inside a request scope. Tests that
+// exercise routes wrapped with withAuthedRoute may default to a session-bound
+// Supabase client which calls cookies() — mock it to a no-op store so those
+// tests can run outside a request scope when they inject their own db.
+jest.mock("next/headers", () => ({
+  cookies: async () => ({
+    getAll: () => [],
+    set: () => undefined,
+  }),
+}));

--- a/lib/with-authed-route.ts
+++ b/lib/with-authed-route.ts
@@ -1,7 +1,6 @@
 import type { NextResponse } from 'next/server'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { supabase } from '@/lib/supabase'
-import { getSessionUser } from '@/lib/supabase-server'
+import { createClient, getSessionUser } from '@/lib/supabase-server'
 import { apiError } from '@/lib/api-response'
 
 export interface AuthedRouteDeps {
@@ -49,7 +48,7 @@ export function withAuthedRoute<D extends AuthedRouteDeps = AuthedRouteDeps>(
     deps?: D | NextRouteContext,
   ): Promise<Response | NextResponse> => {
     const actualDeps = (deps ?? {}) as D
-    const db = actualDeps.db ?? supabase
+    const db = actualDeps.db ?? (await createClient())
     const authFn = actualDeps.authFn ?? getSessionUser
     try {
       const user = await authFn()


### PR DESCRIPTION
## Summary
- Root-cause fix for the 422 "Chess.com username not set" even after setting the username — same bug as #52 but at the shared wrapper level
- `withAuthedRoute` defaulted to the bare anon `supabase` client; every user-scoped SELECT (users, card_state, etc.) hit RLS with no auth.uid() and returned zero rows
- Switch to the cookie-bound `createClient()` and add a jest mock of `next/headers` cookies so tests without an injected db still work

## Test plan
- [x] `npm test` passes 331/331 in the main tree
- [ ] Manual: `/sync` Sync now actually enqueues a sync run
- [ ] Manual: `/api/me` returns the saved chess.com username