### PR TITLE
Lowercase username before hitting Chess.com API

### DIFF
--- a/lib/chess-com/client.ts
+++ b/lib/chess-com/client.ts
@@ -11,7 +11,9 @@ export class ChessComApiError extends Error {
 }
 
 export async function fetchArchiveList(username: string): Promise<string[]> {
-  const url = `${CHESS_COM_BASE}/${username}/archives`
+  // Chess.com's public API is case-sensitive — 'Catalyst030119' returns 301,
+  // 'catalyst030119' returns 200. Normalize at the boundary.
+  const url = `${CHESS_COM_BASE}/${username.toLowerCase()}/archives`
   const response = await fetch(url)
 
   if (!response.ok) {
@@ -71,7 +73,7 @@ export async function fetchMonthlyArchive(
   }
 
   const mm = String(month).padStart(2, '0')
-  const url = `https://api.chess.com/pub/player/${username}/games/${year}/${mm}`
+  const url = `https://api.chess.com/pub/player/${username.toLowerCase()}/games/${year}/${mm}`
 
   const response = await fetch(url)
 


### PR DESCRIPTION
## Summary
- Chess.com's API is case-sensitive (`/Catalyst030119` → 301, `/catalyst030119` → 200)
- Our client built URLs with the exact casing stored in the DB, so mixed-case handles failed the sync with "Chess.com API error: 404/301"
- Lowercase at the boundary in `fetchArchiveList` and `fetchMonthlyArchive`

## Test plan
- [x] `npm test` passes 321/321
- [ ] Manual: sync run with a mixed-case handle succeeds