### PR TITLE
Scaffold Playwright E2E for critical user paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,57 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  playwright:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Placeholder Supabase env so middleware + client instantiation don't throw.
+      # Public (unauthenticated) tests don't need real Supabase connectivity;
+      # authed flows are .skip'd until a real test fixture lands.
+      NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: dev-anon-key
+      CI: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ tsconfig.tsbuildinfo
 
 # Supabase CLI temp files
 supabase/.temp/
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,56 @@
+# E2E Tests (Playwright)
+
+Durable regression tests for critical user journeys. Run in CI on every PR.
+
+## What belongs here
+
+Only flows we'd be angry about silently breaking:
+
+- Public page rendering (landing, login, signup, protected-route redirect)
+- Signup → onboard → first review
+- Settings: change Chess.com handle → persists
+- Sync start → progress → complete
+- Login / logout round-trip
+
+Component behavior and API validation stay in `__tests__/` (jest). One-off
+"does this PR look right?" checks happen via Claude in Chrome, not here.
+
+## Running locally
+
+```bash
+# Run all tests (auto-starts next dev server)
+npm run test:e2e
+
+# Interactive UI mode — best for authoring / debugging
+npm run test:e2e:ui
+
+# Against an already-running server (e.g. a preview deploy)
+PLAYWRIGHT_BASE_URL=https://preview.example.com npm run test:e2e
+```
+
+First-time setup: `npx playwright install chromium` downloads the browser
+binary (~100 MB, one-time).
+
+## Authenticated flows — fixture still needed
+
+`authed-flows.spec.ts` is currently gated by `test.describe.skip(...)`. The
+selectors are real and the tests will run once one of these is in place:
+
+**Option A — seeded test user against a dedicated Supabase project**
+1. Create a long-lived Supabase project for E2E only.
+2. Seed a test user via migration or an admin-key script in `e2e/setup/`.
+3. Set `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` as CI secrets.
+4. Remove the `.skip`.
+
+**Option B — storageState fixture (faster, no real auth per test)**
+1. Log in once in a `global-setup.ts`, save `storageState` to a file.
+2. Reference that file in `playwright.config.ts` under `use.storageState`.
+3. Each test starts already authenticated — no login round-trip on every run.
+
+Option B is preferred for speed. Add it when a real critical-path bug
+motivates having these tests running.
+
+## CI
+
+`.github/workflows/e2e.yml` runs on every PR. Chromium only — Firefox and
+WebKit add ~10 min with near-zero additional signal for a React/Next.js app.

--- a/e2e/authed-flows.spec.ts
+++ b/e2e/authed-flows.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Authenticated critical-path flows.
+ *
+ * These are SKIPPED until the E2E auth fixture is in place — see
+ * `e2e/README.md` for the setup plan. Each test is written against the real
+ * UI selectors so it will run as-is once a test user + session fixture lands.
+ *
+ * Critical paths covered:
+ *  - Settings: change Chess.com handle → persists after reload
+ *  - Onboarding: name → link chess.com → begin import
+ *  - Sync: start → progress updates → complete
+ *  - Login/logout round-trip
+ *
+ * Do not remove `.skip` until the fixture is ready. Flaky E2E tests that get
+ * disabled individually are worse than the whole file being gated behind one
+ * clear blocker.
+ */
+
+test.describe.skip('Authenticated flows (requires test user fixture)', () => {
+  test('settings: change Chess.com handle and persist across reload', async ({ page }) => {
+    // Stub api.chess.com so the test doesn't depend on their public API.
+    await page.route('https://api.chess.com/pub/player/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"username":"test_handle"}' }),
+    )
+
+    await page.goto('/settings')
+
+    const handleInput = page.getByLabel(/username/i).first()
+    await handleInput.fill('test_handle')
+    await page.getByRole('button', { name: /verify/i }).click()
+    await expect(page.getByRole('button', { name: /verified/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /^save$/i }).click()
+    await expect(page.getByText(/saved/i)).toBeVisible()
+
+    await page.reload()
+    await expect(handleInput).toHaveValue('test_handle')
+  })
+
+  test('onboard: name → link chess.com → begin import', async ({ page }) => {
+    await page.route('https://api.chess.com/pub/player/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"username":"test_handle"}' }),
+    )
+
+    await page.goto('/onboard')
+
+    // Step 1: Name (optional — skip)
+    await page.getByRole('button', { name: /skip/i }).click()
+
+    // Step 2: Link
+    await page.getByPlaceholder(/your_handle/i).fill('test_handle')
+    await page.getByRole('button', { name: /verify/i }).click()
+    await expect(page.getByText(/account found/i)).toBeVisible()
+    await page.getByRole('button', { name: /import these games/i }).click()
+
+    // Step 3: Import — just confirm the step renders
+    await expect(page.getByRole('heading', { name: /pull the history/i })).toBeVisible()
+  })
+
+  test('login → dashboard → logout → back at login', async ({ page }) => {
+    // Requires a seeded test user. Credentials pulled from env.
+    const email = process.env.E2E_TEST_USER_EMAIL
+    const password = process.env.E2E_TEST_USER_PASSWORD
+    test.skip(!email || !password, 'Set E2E_TEST_USER_EMAIL/PASSWORD to run this test')
+
+    await page.goto('/login')
+    await page.getByPlaceholder(/you@domain\.com/i).fill(email!)
+    await page.getByPlaceholder(/your password/i).fill(password!)
+    await page.getByRole('button', { name: /sign in/i }).click()
+
+    await expect(page).toHaveURL(/\/dashboard/)
+
+    await page.getByTestId('user-avatar').click()
+    await page.getByTestId('logout-button').click()
+
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/e2e/public-pages.spec.ts
+++ b/e2e/public-pages.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke tests for public (unauthenticated) pages. These run without any
+ * Supabase test fixture — they just confirm the pages render and the primary
+ * CTAs are reachable. If these break, the build is fundamentally wrong.
+ */
+
+test.describe('Public pages', () => {
+  test('landing page renders and links to signup + login', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /begin/i })).toBeVisible()
+  })
+
+  test('login page renders the email/password form', async ({ page }) => {
+    await page.goto('/login')
+
+    await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible()
+    await expect(page.getByPlaceholder(/you@domain\.com/i)).toBeVisible()
+    await expect(page.getByPlaceholder(/your password/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible()
+  })
+
+  test('signup page renders a form', async ({ page }) => {
+    await page.goto('/signup')
+
+    // Signup page should at minimum expose an email input.
+    await expect(page.locator('input[type="email"]').first()).toBeVisible()
+  })
+
+  test('protected route redirects unauthenticated user to login', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+  testPathIgnorePatterns: ["/node_modules/", "/e2e/", "/.next/"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ts-fsrs": "^4.5.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6",
         "@testing-library/react": "^16",
         "@testing-library/user-event": "^14.6.1",
@@ -2997,6 +2998,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -7343,6 +7360,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.0",
@@ -22,6 +24,7 @@
     "ts-fsrs": "^4.5.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^16",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright config for durable E2E regression tests.
+ *
+ * What belongs here: critical user journeys that we'd be angry about silently
+ * regressing. Unit & component tests stay in jest; ad-hoc UI smoke checks
+ * happen via Claude in Chrome, not here.
+ *
+ * Running locally:   npm run test:e2e
+ * Interactive UI:    npm run test:e2e:ui
+ * In CI:             same npm run test:e2e (with CI=1 env)
+ */
+const PORT = Number(process.env.PORT ?? 3000)
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // Auto-start the Next.js dev server when running locally or in CI.
+  // Override with PLAYWRIGHT_BASE_URL to point at an already-running preview.
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+})


### PR DESCRIPTION
## Summary
- Adds **Playwright** as a dev dependency (Apache 2.0, free) for durable E2E regression tests on the flows we'd be angry about silently breaking.
- **Chromium only** — Firefox/WebKit add ~10 min of CI time with near-zero additional signal for a Next.js/React app.
- Ships with 4 passing smoke tests (landing, login, signup, protected-route redirect) and skeletons for the authed critical paths (settings handle update, onboarding, login/logout).

## What's in the box
| Path | What it does |
|---|---|
| `playwright.config.ts` | Chromium project, auto-starts `next dev`, trace on retry, screenshot + video on failure. |
| `e2e/public-pages.spec.ts` | ✅ 4 runnable tests — no fixture needed. |
| `e2e/authed-flows.spec.ts` | ⏸ `.skip`'d critical paths with real selectors, ready to unskip once an auth fixture lands. |
| `e2e/README.md` | Local/CI instructions + two paths forward for the auth fixture. |
| `.github/workflows/e2e.yml` | Runs on every PR. Caches browser binary. Uploads HTML report on failure. |

## Cost
- Playwright: **$0** (OSS from Microsoft).
- CI minutes: ~2 min / PR run. GitHub Actions free tier on public repos is unlimited; on private repos 2,000 min/mo (Pro: 3,000).
- Local disk: ~100 MB for Chromium binary, one-time.

## Test plan
- [x] `npm run test:e2e` locally — 4 passing, 3 skipped (12s).
- [x] `npm test` — 331 jest tests still pass, `/e2e/` excluded via `testPathIgnorePatterns`.
- [ ] CI green on this PR.

## Out of scope (intentional follow-up)
Authenticated flows stay skipped. Unskipping requires either:
1. A seeded test user on a dedicated Supabase project + CI secrets, or
2. A `storageState` fixture from a one-time logged-in setup.

See `e2e/README.md` — Option B (storageState) is preferred when the need arises. Not worth building speculatively; the selectors are already written so the tests run as-is once the fixture lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)