### PR TITLE
Fix Chess.com archive URL and send a User-Agent

### DIFF
--- a/lib/chess-com/client.ts
+++ b/lib/chess-com/client.ts
@@ -1,5 +1,13 @@
 const CHESS_COM_BASE = 'https://api.chess.com/pub/player'
 
+// Chess.com's public API rejects/rate-limits requests without a User-Agent.
+// Identify the app and include a contact address per their guidelines.
+const USER_AGENT = 'ChessImprover/1.0 (https://chess-game-reviewer.vercel.app)'
+
+function chessComHeaders(): HeadersInit {
+  return { 'User-Agent': USER_AGENT }
+}
+
 export class ChessComApiError extends Error {
   constructor(
     message: string,
@@ -13,8 +21,9 @@ export class ChessComApiError extends Error {
 export async function fetchArchiveList(username: string): Promise<string[]> {
   // Chess.com's public API is case-sensitive — 'Catalyst030119' returns 301,
   // 'catalyst030119' returns 200. Normalize at the boundary.
-  const url = `${CHESS_COM_BASE}/${username.toLowerCase()}/archives`
-  const response = await fetch(url)
+  // The archives index lives at /games/archives, NOT /archives.
+  const url = `${CHESS_COM_BASE}/${username.toLowerCase()}/games/archives`
+  const response = await fetch(url, { headers: chessComHeaders() })
 
   if (!response.ok) {
     throw new ChessComApiError(
@@ -45,7 +54,7 @@ export async function fetchGames(
       await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
 
-    const response = await fetch(archiveUrl)
+    const response = await fetch(archiveUrl, { headers: chessComHeaders() })
     if (!response.ok) {
       throw new ChessComApiError(
         `Chess.com API error: ${response.status}`,
@@ -75,7 +84,7 @@ export async function fetchMonthlyArchive(
   const mm = String(month).padStart(2, '0')
   const url = `https://api.chess.com/pub/player/${username.toLowerCase()}/games/${year}/${mm}`
 
-  const response = await fetch(url)
+  const response = await fetch(url, { headers: chessComHeaders() })
 
   if (!response.ok) {
     throw new ChessComApiError(


### PR DESCRIPTION
## Summary
- Archives index lives at `/pub/player/<u>/games/archives`, not `/pub/player/<u>/archives` — the old path returns 404 even for valid players with games
- Chess.com rejects/rate-limits requests without a User-Agent header; add one per their guidelines
- Also wires the User-Agent through the monthly-archive fetch

## Test plan
- [x] `npm test` passes 321/321
- [ ] Manual: sync a real player's history end-to-end without a 404