### PR TITLE
Serialize sync errors properly

### DIFF
--- a/__tests__/lib/chess-com/client.test.ts
+++ b/__tests__/lib/chess-com/client.test.ts
@@ -65,7 +65,8 @@ describe('fetchMonthlyArchive', () => {
 
     expect(result).toEqual([FAKE_PGN_1, FAKE_PGN_2])
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.chess.com/pub/player/testuser/games/2024/03'
+      'https://api.chess.com/pub/player/testuser/games/2024/03',
+      expect.objectContaining({ headers: expect.any(Object) }),
     )
   })
 })

--- a/__tests__/lib/chess-com/fetchGames.test.ts
+++ b/__tests__/lib/chess-com/fetchGames.test.ts
@@ -1,6 +1,6 @@
 import { fetchGames } from '../../../lib/chess-com/client'
 
-const ARCHIVE_LIST_URL = 'https://api.chess.com/pub/player/testuser/archives'
+const ARCHIVE_LIST_URL = 'https://api.chess.com/pub/player/testuser/games/archives'
 const ARCHIVE_JAN = 'https://api.chess.com/pub/player/testuser/games/2024/01'
 const ARCHIVE_FEB = 'https://api.chess.com/pub/player/testuser/games/2024/02'
 const ARCHIVE_MAR = 'https://api.chess.com/pub/player/testuser/games/2024/03'
@@ -10,6 +10,8 @@ const PGN_FEB = '[Event "Live Chess"]\n1. d4 d5 *'
 const PGN_MAR = '[Event "Live Chess"]\n1. c4 c5 *'
 
 function makeFetchMock(responses: Record<string, { status: number; body: unknown }>) {
+  // fetchGames now passes a second arg (`{ headers: { User-Agent } }`) to every
+  // fetch call. Ignore it here and match by URL alone.
   return jest.fn().mockImplementation((url: string) => {
     const entry = responses[url]
     if (!entry) throw new Error(`Unexpected fetch call: ${url}`)
@@ -42,8 +44,8 @@ describe('fetchGames — incremental mode', () => {
 
     expect(result).toEqual([PGN_MAR])
     expect(global.fetch).toHaveBeenCalledTimes(2)
-    expect(global.fetch).toHaveBeenCalledWith(ARCHIVE_LIST_URL)
-    expect(global.fetch).toHaveBeenCalledWith(ARCHIVE_MAR)
+    expect(global.fetch).toHaveBeenCalledWith(ARCHIVE_LIST_URL, expect.anything())
+    expect(global.fetch).toHaveBeenCalledWith(ARCHIVE_MAR, expect.anything())
   })
 
   it('returns empty array when archive list is empty', async () => {

--- a/lib/sync-orchestrator.ts
+++ b/lib/sync-orchestrator.ts
@@ -34,6 +34,29 @@ export interface SyncOptions {
   onProgress?: (progress: SyncProgress) => Promise<void> | void
 }
 
+/**
+ * Serialize an unknown thrown value into a useful one-line string.
+ *
+ * Supabase surfaces DB errors as plain objects (`{ message, code, details,
+ * hint }`) rather than `Error` instances, so `err instanceof Error` is false
+ * and `String(err)` gives "[object Object]" — which is exactly the useless
+ * string we were storing in sync_log.error.
+ */
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (err && typeof err === 'object') {
+    const e = err as Record<string, unknown>
+    const parts: string[] = []
+    if (typeof e.message === 'string') parts.push(e.message)
+    if (typeof e.code === 'string') parts.push(`code=${e.code}`)
+    if (typeof e.details === 'string') parts.push(`details=${e.details}`)
+    if (typeof e.hint === 'string') parts.push(`hint=${e.hint}`)
+    if (parts.length > 0) return parts.join(' · ')
+    try { return JSON.stringify(err) } catch { return '[unserialisable error]' }
+  }
+  return String(err)
+}
+
 async function ensureGameRow(
   db: SupabaseClient,
   userId: string,
@@ -103,7 +126,7 @@ export async function runSync(
       gamesProcessed++
       cardsCreated += result.created
     } catch (err) {
-      errors.push(err instanceof Error ? err.message : String(err))
+      errors.push(formatError(err))
     }
 
     await onProgress?.({


### PR DESCRIPTION
## Summary
- Caught Supabase errors were being stored as "[object Object]" in `sync_log.error` because they're plain objects, not `Error` instances
- Add `formatError()` that extracts `message`/`code`/`details`/`hint` into a readable string
- Fix chess-com tests that were still asserting the old `/archives` path (without `/games/`) and not accounting for the User-Agent arg

## Test plan
- [x] `npm test` → 331/331 passing
- [ ] Manual: next failing sync surfaces a human-readable error in `sync_log.error`