### PR TITLE
Fix duplicate formatError breaking Vercel build

### DIFF
--- a/lib/sync-orchestrator.ts
+++ b/lib/sync-orchestrator.ts
@@ -122,29 +122,6 @@ function safeStringify(v: unknown): string {
   try { return JSON.stringify(v) } catch { return '[unserialisable]' }
 }
 
-/**
- * Serialize an unknown thrown value into a useful one-line string.
- *
- * Supabase surfaces DB errors as plain objects (`{ message, code, details,
- * hint }`) rather than `Error` instances, so `err instanceof Error` is false
- * and `String(err)` gives "[object Object]" — which is exactly the useless
- * string we were storing in sync_log.error.
- */
-function formatError(err: unknown): string {
-  if (err instanceof Error) return err.message
-  if (err && typeof err === 'object') {
-    const e = err as Record<string, unknown>
-    const parts: string[] = []
-    if (typeof e.message === 'string') parts.push(e.message)
-    if (typeof e.code === 'string') parts.push(`code=${e.code}`)
-    if (typeof e.details === 'string') parts.push(`details=${e.details}`)
-    if (typeof e.hint === 'string') parts.push(`hint=${e.hint}`)
-    if (parts.length > 0) return parts.join(' · ')
-    try { return JSON.stringify(err) } catch { return '[unserialisable error]' }
-  }
-  return String(err)
-}
-
 async function ensureGameRow(
   db: SupabaseClient,
   userId: string,


### PR DESCRIPTION
## Summary

- The squash merge of #60 combined my branch's base commit (a parallel of the already-squashed #58) with the new file content, producing two `formatError` declarations and failing `next build`.
- Deletes the stale function body; behavior is unchanged.

## Test plan

- [x] `npx tsc --noEmit` — clean on orchestrator files
- [x] Orchestrator + step-logger tests green (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)