### PR TITLE
Use session-bound client in /api/sync/[id]/steps

### DIFF
--- a/__tests__/api/sync-steps.test.ts
+++ b/__tests__/api/sync-steps.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/sync/[id]/steps/route'
+import { makeMockDb } from '@/__tests__/helpers/mock-db'
+
+const USER_ID = 'dev-user-id'
+const SYNC_ID = 'sync-abc'
+const AUTH_FN = async () => ({ id: USER_ID })
+
+function makeReq() {
+  return new Request(`http://localhost/api/sync/${SYNC_ID}/steps`, { method: 'GET' })
+}
+
+function params(id: string) {
+  return Promise.resolve({ id })
+}
+
+const SYNC_LOG_ROW = {
+  id: SYNC_ID,
+  user_id: USER_ID,
+  mode: 'incremental',
+  started_at: '2024-01-01T00:00:00Z',
+  completed_at: '2024-01-01T00:01:00Z',
+  error: null,
+  games_processed: 2,
+  cards_created: 1,
+  games_total: 2,
+  stage: 'complete',
+}
+
+const STEP_ROWS = [
+  {
+    id: 'step-1',
+    sync_log_id: SYNC_ID,
+    game_url: null,
+    game_index: null,
+    step: 'sync-start',
+    status: 'ok',
+    duration_ms: 5,
+    error: null,
+    error_code: null,
+    details: { mode: 'incremental' },
+    created_at: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'step-2',
+    sync_log_id: SYNC_ID,
+    game_url: 'https://chess.com/game/1',
+    game_index: 0,
+    step: 'analyze',
+    status: 'ok',
+    duration_ms: 220,
+    error: null,
+    error_code: null,
+    details: null,
+    created_at: '2024-01-01T00:00:01.000Z',
+  },
+]
+
+describe('GET /api/sync/[id]/steps', () => {
+  it('returns sync + steps for the owner', async () => {
+    const { db } = makeMockDb({
+      sync_log: [SYNC_LOG_ROW],
+      sync_step_log: STEP_ROWS,
+    })
+
+    const res = await GET(makeReq(), { db, authFn: AUTH_FN, params: params(SYNC_ID) })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.sync.id).toBe(SYNC_ID)
+    expect(body.sync.stage).toBe('complete')
+    expect(body.steps).toHaveLength(2)
+    expect(body.steps[0].step).toBe('sync-start')
+    expect(body.steps[1].step).toBe('analyze')
+  })
+
+  it('404s when the sync_log row is owned by someone else', async () => {
+    const { db } = makeMockDb({
+      sync_log: [{ ...SYNC_LOG_ROW, user_id: 'other-user' }],
+      sync_step_log: STEP_ROWS,
+    })
+
+    const res = await GET(makeReq(), { db, authFn: AUTH_FN, params: params(SYNC_ID) })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('404s when the sync_log row does not exist', async () => {
+    const { db } = makeMockDb({ sync_log: [], sync_step_log: [] })
+
+    const res = await GET(makeReq(), { db, authFn: AUTH_FN, params: params(SYNC_ID) })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('401s when unauthenticated', async () => {
+    const { db } = makeMockDb({ sync_log: [SYNC_LOG_ROW], sync_step_log: STEP_ROWS })
+
+    const res = await GET(makeReq(), {
+      db,
+      authFn: async () => null,
+      params: params(SYNC_ID),
+    })
+
+    expect(res.status).toBe(401)
+  })
+})

--- a/app/api/sync/[id]/steps/route.ts
+++ b/app/api/sync/[id]/steps/route.ts
@@ -1,32 +1,32 @@
 import { NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
-import { getSessionUser } from '@/lib/supabase-server'
+import { withAuthedRoute, type AuthedRouteDeps } from '@/lib/with-authed-route'
+import { apiError } from '@/lib/api-response'
 
-type Ctx = { params: Promise<{ id: string }> }
+interface StepsRouteDeps extends AuthedRouteDeps {
+  params: Promise<{ id: string }>
+}
 
-export async function GET(_req: Request, ctx: Ctx) {
-  const user = await getSessionUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+export const GET = withAuthedRoute<StepsRouteDeps>(async ({ db, user, deps }) => {
+  const { id } = await deps.params
 
-  const { id } = await ctx.params
-
-  // Verify the sync_log row belongs to this user — RLS will also enforce this,
-  // but a 404 here keeps error messages honest for non-owners.
-  const { data: parent } = await supabase
+  // Verify the sync_log row belongs to this user — RLS also enforces it on the
+  // session-bound client, but the explicit 404 keeps error messages honest for
+  // non-owners.
+  const { data: parent } = await db
     .from('sync_log')
     .select('id, user_id, mode, started_at, completed_at, error, games_processed, cards_created, games_total, stage')
     .eq('id', id)
     .eq('user_id', user.id)
     .maybeSingle()
-  if (!parent) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (!parent) return apiError(404, 'Not found')
 
-  const { data: steps, error } = await supabase
+  const { data: steps, error } = await db
     .from('sync_step_log')
     .select('id, game_url, game_index, step, status, duration_ms, error, error_code, details, created_at')
     .eq('sync_log_id', id)
     .order('created_at', { ascending: true })
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) return apiError(500, error.message)
 
   return NextResponse.json({ sync: parent, steps: steps ?? [] })
-}
+})


### PR DESCRIPTION
## Summary
- The new audit route (PR #60) was built on the anon-key `supabase` client from `lib/supabase.ts`. With no session, `auth.uid()` is null in Postgres, so the `sync_log` and `sync_step_log` RLS policies filter out every row — including the owner's. The manual `.eq('user_id', user.id)` check never saw rows to reject, and returned 404 for everyone.
- Converts the route to the `withAuthedRoute` pattern used by `/api/sync/status` and `/api/sync/progress`, which threads a session-bound `db` and the authenticated `user` through. No SQL changes.
- Adds `__tests__/api/sync-steps.test.ts` covering owner (200), non-owner (404), missing row (404), and unauthenticated (401).

## Test plan
- [x] `npx jest __tests__/api/sync-steps.test.ts` — 4 passed
- [x] Full jest run — no new failures (pre-existing failures are in `.claude/worktrees/`, unrelated)
- [ ] After deploy: open `/sync/<a real sync id>` — step rows should render where previously the page said "Failed to load: Request failed (404)"
- [ ] After deploy: confirm `/sync/<invalid-uuid>` still 404s (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)