### PR TITLE
Fix /api/sync/history to use session-bound Supabase client

### DIFF
--- a/__tests__/api/sync-history.test.ts
+++ b/__tests__/api/sync-history.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/sync/history/route'
+import { makeMockDb } from '@/__tests__/helpers/mock-db'
+
+const USER_ID = 'dev-user-id'
+const AUTH_FN = async () => ({ id: USER_ID })
+
+function makeReq() {
+  return new Request('http://localhost/api/sync/history', { method: 'GET' })
+}
+
+const OWN_LOGS = [
+  { id: 'own-1', user_id: USER_ID, mode: 'incremental', started_at: '2024-01-03T00:00:00Z' },
+  { id: 'own-2', user_id: USER_ID, mode: 'incremental', started_at: '2024-01-02T00:00:00Z' },
+  { id: 'own-3', user_id: USER_ID, mode: 'historical',  started_at: '2024-01-01T00:00:00Z' },
+]
+
+const OTHER_LOG = {
+  id: 'other-1',
+  user_id: 'some-other-user',
+  mode: 'incremental',
+  started_at: '2024-01-04T00:00:00Z',
+}
+
+describe('GET /api/sync/history', () => {
+  it('returns only the caller’s runs, newest first', async () => {
+    const { db } = makeMockDb({ sync_log: [OTHER_LOG, ...OWN_LOGS] })
+
+    const res = await GET(makeReq(), { db, authFn: AUTH_FN })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toHaveLength(3)
+    expect(body.map((r: { id: string }) => r.id)).toEqual(['own-1', 'own-2', 'own-3'])
+  })
+
+  it('returns an empty list when the user has no runs', async () => {
+    const { db } = makeMockDb({ sync_log: [OTHER_LOG] })
+
+    const res = await GET(makeReq(), { db, authFn: AUTH_FN })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual([])
+  })
+
+  it('401s when unauthenticated', async () => {
+    const { db } = makeMockDb({ sync_log: OWN_LOGS })
+
+    const res = await GET(makeReq(), { db, authFn: async () => null })
+
+    expect(res.status).toBe(401)
+  })
+})

--- a/app/api/sync/history/route.ts
+++ b/app/api/sync/history/route.ts
@@ -1,23 +1,16 @@
 import { NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
-import { getSessionUser } from '@/lib/supabase-server'
+import { withAuthedRoute } from '@/lib/with-authed-route'
+import { apiError } from '@/lib/api-response'
 
-export async function GET() {
-  const user = await getSessionUser()
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const { data, error } = await supabase
+export const GET = withAuthedRoute(async ({ db, user }) => {
+  const { data, error } = await db
     .from('sync_log')
     .select('*')
     .eq('user_id', user.id)
     .order('started_at', { ascending: false })
     .limit(7)
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
-  }
+  if (error) return apiError(500, error.message)
 
   return NextResponse.json(data ?? [])
-}
+})


### PR DESCRIPTION
## Summary
- `/api/sync/history` used the anon-key Supabase client, so RLS saw no authenticated user and the query returned an empty list in prod
- Switch to `withAuthedRoute` so the query runs as the session user — same fix pattern as #62 for `/api/sync/[id]/steps`
- Add jest coverage for owner-only scoping, empty result, and 401 unauthenticated

## Test plan
- [x] `npx jest __tests__/api/sync-history.test.ts` — 3/3 pass
- [ ] After merge, verify `/sync` page in prod shows recent run history for the signed-in user

🤖 Generated with [Claude Code](https://claude.com/claude-code)