### PR TITLE
Plan C: make stuck sync runs recover gracefully

### DIFF
--- a/__tests__/lib/inngest-terminal-state.test.ts
+++ b/__tests__/lib/inngest-terminal-state.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+
+import { markSyncFailed } from '@/lib/inngest/terminal-state'
+import { makeMockDb } from '@/__tests__/helpers/mock-db'
+
+const SYNC_ID = 'sync-xyz'
+
+describe('markSyncFailed', () => {
+  it('sets stage=error, completed_at, and error message on the sync_log row', async () => {
+    const { db, updated } = makeMockDb({
+      sync_log: [{ id: SYNC_ID, stage: 'analyzing', completed_at: null, error: null }],
+    })
+
+    await markSyncFailed(db, SYNC_ID, 'Sync timed out after retries')
+
+    const log = updated.sync_log?.[0]
+    expect(log).toBeDefined()
+    expect(log!.values.stage).toBe('error')
+    expect(log!.values.error).toBe('Sync timed out after retries')
+    expect(typeof log!.values.completed_at).toBe('string')
+    expect(log!.filters).toEqual([{ op: 'eq', col: 'id', val: SYNC_ID }])
+  })
+
+  it('truncates long error messages to keep the DB row small', async () => {
+    const { db, updated } = makeMockDb({
+      sync_log: [{ id: SYNC_ID, stage: 'analyzing' }],
+    })
+
+    const longMsg = 'x'.repeat(5000)
+    await markSyncFailed(db, SYNC_ID, longMsg)
+
+    const stored = updated.sync_log![0].values.error as string
+    expect(stored.length).toBeLessThanOrEqual(2000)
+  })
+})

--- a/__tests__/lib/poll-sync-progress.test.ts
+++ b/__tests__/lib/poll-sync-progress.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment node
+ */
+
+import { pollSyncUntilTerminal } from '@/lib/poll-sync-progress'
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+describe('pollSyncUntilTerminal', () => {
+  it("resolves to 'complete' when the server reports stage=complete", async () => {
+    const stages = ['queued', 'fetching', 'analyzing', 'complete']
+    let call = 0
+    const fetchFn = jest.fn(async () => jsonResponse({ stage: stages[call++] }))
+
+    const result = await pollSyncUntilTerminal('sync-1', {
+      fetchFn,
+      sleepFn: async () => {},
+      maxAttempts: 10,
+    })
+
+    expect(result.outcome).toBe('complete')
+    expect(fetchFn).toHaveBeenCalledTimes(4)
+  })
+
+  it("resolves to 'error' and surfaces the server message", async () => {
+    const fetchFn = jest.fn(async () =>
+      jsonResponse({ stage: 'error', error: 'Chess.com 404' }),
+    )
+
+    const result = await pollSyncUntilTerminal('sync-2', {
+      fetchFn,
+      sleepFn: async () => {},
+      maxAttempts: 5,
+    })
+
+    expect(result.outcome).toBe('error')
+    expect(result.error).toBe('Chess.com 404')
+  })
+
+  it("gives up with outcome='timeout' after maxAttempts when stage never becomes terminal", async () => {
+    const fetchFn = jest.fn(async () => jsonResponse({ stage: 'analyzing' }))
+
+    const result = await pollSyncUntilTerminal('sync-3', {
+      fetchFn,
+      sleepFn: async () => {},
+      maxAttempts: 5,
+    })
+
+    expect(result.outcome).toBe('timeout')
+    expect(fetchFn).toHaveBeenCalledTimes(5)
+  })
+
+  it('ignores transient fetch errors and keeps polling', async () => {
+    const responses = [
+      () => { throw new Error('network') },
+      () => jsonResponse({ ok: false } as unknown as Response),
+      () => jsonResponse({ stage: 'complete' }),
+    ]
+    let call = 0
+    const fetchFn = jest.fn(async () => {
+      const next = responses[call++]
+      const out = next()
+      if (out instanceof Error) throw out
+      return out as Response
+    })
+
+    const result = await pollSyncUntilTerminal('sync-4', {
+      fetchFn,
+      sleepFn: async () => {},
+      maxAttempts: 10,
+    })
+
+    expect(result.outcome).toBe('complete')
+  })
+
+  it('emits onProgress for every successful poll', async () => {
+    const stages = ['fetching', 'analyzing', 'complete']
+    let call = 0
+    const fetchFn = jest.fn(async () =>
+      jsonResponse({ stage: stages[call++], games_done: call, games_total: 3 }),
+    )
+    const onProgress = jest.fn()
+
+    await pollSyncUntilTerminal('sync-5', {
+      fetchFn,
+      sleepFn: async () => {},
+      maxAttempts: 10,
+      onProgress,
+    })
+
+    expect(onProgress).toHaveBeenCalledTimes(3)
+    expect(onProgress).toHaveBeenNthCalledWith(1, expect.objectContaining({ stage: 'fetching' }))
+    expect(onProgress).toHaveBeenNthCalledWith(3, expect.objectContaining({ stage: 'complete' }))
+  })
+})

--- a/__tests__/lib/sync-run-status.test.ts
+++ b/__tests__/lib/sync-run-status.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+
+import { syncRunStatusLabel } from '@/lib/sync-run-status'
+import type { SyncLog } from '@/types/database'
+
+function log(partial: Partial<SyncLog>): SyncLog {
+  return {
+    id: 's',
+    user_id: 'u',
+    mode: 'incremental',
+    started_at: '2024-01-01T00:00:00Z',
+    completed_at: null,
+    games_processed: 0,
+    cards_created: 0,
+    error: null,
+    stage: null,
+    games_total: 0,
+    ...partial,
+  }
+}
+
+describe('syncRunStatusLabel', () => {
+  it('returns success when stage=complete and no error', () => {
+    expect(syncRunStatusLabel(log({ stage: 'complete' }))).toEqual({
+      label: 'All stages green',
+      tone: 'success',
+    })
+  })
+
+  it('returns error when the server recorded an error message', () => {
+    expect(syncRunStatusLabel(log({ stage: 'error', error: 'Chess.com 404' }))).toEqual({
+      label: 'Chess.com 404',
+      tone: 'error',
+    })
+  })
+
+  it('returns error with a fallback label when stage=error but no message', () => {
+    expect(syncRunStatusLabel(log({ stage: 'error' }))).toEqual({
+      label: 'Sync failed',
+      tone: 'error',
+    })
+  })
+
+  it('returns warn when stage is not terminal (run never finished)', () => {
+    expect(syncRunStatusLabel(log({ stage: 'analyzing' }))).toEqual({
+      label: 'Run did not finish',
+      tone: 'warn',
+    })
+  })
+
+  it('returns warn when stage is missing entirely (legacy rows)', () => {
+    expect(syncRunStatusLabel(log({ stage: null }))).toEqual({
+      label: 'Run did not finish',
+      tone: 'warn',
+    })
+  })
+
+  it('prefers the explicit error message even if stage claims complete', () => {
+    // Guards against weird race where completed_at was written with a
+    // partial-failure error attached.
+    expect(syncRunStatusLabel(log({ stage: 'complete', error: 'Partial failure' }))).toEqual({
+      label: 'Partial failure',
+      tone: 'error',
+    })
+  })
+})

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Logo, Button, Field, Input } from '@/components/ui'
 import { createClient } from '@/lib/supabase-browser'
+import { pollSyncUntilTerminal } from '@/lib/poll-sync-progress'
 
 const STAGE_LABEL: Record<string, string> = {
   queued:    'Queued — worker picking up the job',
@@ -271,32 +272,20 @@ function ImportStep({ username, onDone }: { username: string; onDone: () => void
       return
     }
 
-    let terminalStage: 'complete' | 'error' | null = null
-    let terminalError: string | null = null
+    const result = await pollSyncUntilTerminal(syncId, {
+      onProgress: (snap) => {
+        setStage(snap.stage ?? 'queued')
+        setGamesDone(snap.games_done ?? 0)
+        setGamesTotal(snap.games_total ?? 0)
+        setCardsCreated(snap.cards_created ?? 0)
+      },
+    })
 
-    // Poll once a second until terminal state
-    while (terminalStage === null) {
-      await new Promise((r) => setTimeout(r, 1000))
-      try {
-        const res = await fetch(`/api/sync/progress?id=${encodeURIComponent(syncId)}`)
-        if (!res.ok) continue
-        const data = await res.json()
-        setStage(data.stage ?? 'queued')
-        setGamesDone(data.games_done ?? 0)
-        setGamesTotal(data.games_total ?? 0)
-        setCardsCreated(data.cards_created ?? 0)
-        if (data.stage === 'complete') terminalStage = 'complete'
-        else if (data.stage === 'error') {
-          terminalStage = 'error'
-          terminalError = data.error ?? 'Sync failed'
-        }
-      } catch {
-        // Transient network error — keep polling
-      }
-    }
-
-    if (terminalStage === 'error') {
-      setError(terminalError ?? 'Sync failed')
+    if (result.outcome === 'error') {
+      setError(result.error ?? 'Sync failed')
+      setRunning(false)
+    } else if (result.outcome === 'timeout') {
+      setError('Sync is taking longer than expected. You can continue — it will finish in the background.')
       setRunning(false)
     } else {
       setTimeout(onDone, 800)

--- a/app/sync/page.tsx
+++ b/app/sync/page.tsx
@@ -5,7 +5,20 @@ import Link from 'next/link'
 import { Nav, Page, Button, Stat } from '@/components/ui'
 import { useSyncStatus, useSyncHistory } from '@/hooks/dashboard'
 import { pollSyncUntilTerminal } from '@/lib/poll-sync-progress'
+import { syncRunStatusLabel, type StatusTone } from '@/lib/sync-run-status'
 import type { SyncLog } from '@/types/database'
+
+const TONE_DOT: Record<StatusTone, string> = {
+  success: 'var(--good)',
+  error: 'var(--amber)',
+  warn: 'var(--amber)',
+}
+
+const TONE_TEXT: Record<StatusTone, string> = {
+  success: 'var(--muted)',
+  error: 'var(--ink-2)',
+  warn: 'var(--ink-2)',
+}
 
 export default function SyncPage() {
   const statusFetch = useSyncStatus()
@@ -165,34 +178,37 @@ export default function SyncPage() {
               </div>
             )}
 
-            {history.map((log, i) => (
-              <Link key={log.id} href={`/sync/${log.id}`} style={{
-                display: 'grid', gridTemplateColumns: '200px 120px 1fr 100px 100px', gap: 20,
-                padding: '14px 20px', alignItems: 'center',
-                borderBottom: i < history.length - 1 ? '1px solid var(--line)' : 'none',
-                background: 'var(--bg)', color: 'inherit', textDecoration: 'none',
-              }}>
-                <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                  <div style={{
-                    width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
-                    background: log.error ? 'var(--amber)' : 'var(--good)',
-                  }} />
-                  <span className="mono" style={{ fontSize: 12 }}>
-                    {new Date(log.started_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                    {' · '}
-                    {new Date(log.started_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}
+            {history.map((log, i) => {
+              const status = syncRunStatusLabel(log)
+              return (
+                <Link key={log.id} href={`/sync/${log.id}`} style={{
+                  display: 'grid', gridTemplateColumns: '200px 120px 1fr 100px 100px', gap: 20,
+                  padding: '14px 20px', alignItems: 'center',
+                  borderBottom: i < history.length - 1 ? '1px solid var(--line)' : 'none',
+                  background: 'var(--bg)', color: 'inherit', textDecoration: 'none',
+                }}>
+                  <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                    <div style={{
+                      width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+                      background: TONE_DOT[status.tone],
+                    }} />
+                    <span className="mono" style={{ fontSize: 12 }}>
+                      {new Date(log.started_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                      {' · '}
+                      {new Date(log.started_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                  </div>
+                  <span className="mono" style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--muted)' }}>
+                    {log.mode}
                   </span>
-                </div>
-                <span className="mono" style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--muted)' }}>
-                  {log.mode}
-                </span>
-                <span style={{ fontSize: 13, color: log.error ? 'var(--ink-2)' : 'var(--muted)' }}>
-                  {log.error ?? 'All stages green'}
-                </span>
-                <span className="serif" style={{ fontSize: 20, letterSpacing: '-0.02em' }}>{log.games_processed}</span>
-                <span className="serif" style={{ fontSize: 20, letterSpacing: '-0.02em' }}>{log.cards_created}</span>
-              </Link>
-            ))}
+                  <span style={{ fontSize: 13, color: TONE_TEXT[status.tone] }}>
+                    {status.label}
+                  </span>
+                  <span className="serif" style={{ fontSize: 20, letterSpacing: '-0.02em' }}>{log.games_processed}</span>
+                  <span className="serif" style={{ fontSize: 20, letterSpacing: '-0.02em' }}>{log.cards_created}</span>
+                </Link>
+              )
+            })}
           </div>
         </div>
       </Page>

--- a/app/sync/page.tsx
+++ b/app/sync/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { Nav, Page, Button, Stat } from '@/components/ui'
 import { useSyncStatus, useSyncHistory } from '@/hooks/dashboard'
+import { pollSyncUntilTerminal } from '@/lib/poll-sync-progress'
 import type { SyncLog } from '@/types/database'
 
 export default function SyncPage() {
@@ -41,25 +42,17 @@ export default function SyncPage() {
     }
     const { sync_id } = await res.json()
 
-    // Poll progress until terminal
-    let terminal: 'complete' | 'error' | null = null
-    while (terminal === null) {
-      await new Promise((r) => setTimeout(r, 1000))
-      try {
-        const pr = await fetch(`/api/sync/progress?id=${encodeURIComponent(sync_id)}`)
-        if (!pr.ok) continue
-        const data = await pr.json()
-        setProgressStage(data.stage ?? 'queued')
-        setProgressDone(data.games_done ?? 0)
-        setProgressTotal(data.games_total ?? 0)
-        if (data.stage === 'complete') terminal = 'complete'
-        else if (data.stage === 'error') {
-          terminal = 'error'
-          setSyncError(data.error ?? 'Sync failed')
-        }
-      } catch {
-        // keep polling
-      }
+    const result = await pollSyncUntilTerminal(sync_id, {
+      onProgress: (snap) => {
+        setProgressStage(snap.stage ?? 'queued')
+        setProgressDone(snap.games_done ?? 0)
+        setProgressTotal(snap.games_total ?? 0)
+      },
+    })
+    if (result.outcome === 'error') {
+      setSyncError(result.error ?? 'Sync failed')
+    } else if (result.outcome === 'timeout') {
+      setSyncError('Sync is taking longer than expected — check back on this page in a minute.')
     }
 
     statusFetch.refetch()

--- a/lib/inngest/functions.ts
+++ b/lib/inngest/functions.ts
@@ -3,6 +3,7 @@ import { inngest } from './client'
 import { runSync, type SyncProgress } from '@/lib/sync-orchestrator'
 import { createServiceClient } from '@/lib/supabase-service'
 import { makeSupabaseStepLogger } from '@/lib/sync-step-logger'
+import { markSyncFailed } from './terminal-state'
 
 export interface SyncGamesDeps {
   db?: SupabaseClient
@@ -19,6 +20,17 @@ export const syncGamesFunction = inngest.createFunction(
     id: 'sync-games',
     name: 'Sync Chess.com games',
     triggers: [{ event: 'sync/run' }],
+    // Runs after all retries are exhausted. Without this, a function that
+    // times out or crashes mid-run leaves sync_log.stage stuck on whatever
+    // the last onProgress write was (usually 'analyzing'), and the client
+    // polls forever because it's waiting for a terminal stage.
+    onFailure: async ({ event, error }) => {
+      const { syncLogId } = (event.data.event?.data ?? {}) as { syncLogId?: string }
+      if (!syncLogId) return
+      const db = createServiceClient()
+      const message = error instanceof Error ? error.message : String(error)
+      await markSyncFailed(db, syncLogId, message)
+    },
   },
   async ({ event, step }) => {
     const { syncLogId, userId, username, mode } = event.data as {
@@ -72,14 +84,7 @@ export const syncGamesFunction = inngest.createFunction(
       return result
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      await db
-        .from('sync_log')
-        .update({
-          stage: 'error',
-          completed_at: new Date().toISOString(),
-          error: message,
-        })
-        .eq('id', syncLogId)
+      await markSyncFailed(db, syncLogId, message)
       throw err
     }
   },

--- a/lib/inngest/terminal-state.ts
+++ b/lib/inngest/terminal-state.ts
@@ -1,0 +1,19 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const MAX_ERROR_LEN = 2000
+
+export async function markSyncFailed(
+  db: SupabaseClient,
+  syncLogId: string,
+  message: string,
+): Promise<void> {
+  const truncated = message.length > MAX_ERROR_LEN ? message.slice(0, MAX_ERROR_LEN) : message
+  await db
+    .from('sync_log')
+    .update({
+      stage: 'error',
+      completed_at: new Date().toISOString(),
+      error: truncated,
+    })
+    .eq('id', syncLogId)
+}

--- a/lib/poll-sync-progress.ts
+++ b/lib/poll-sync-progress.ts
@@ -1,0 +1,54 @@
+export interface SyncProgressSnapshot {
+  stage: string
+  games_done?: number
+  games_total?: number
+  cards_created?: number
+  error?: string | null
+}
+
+export type PollOutcome = 'complete' | 'error' | 'timeout'
+
+export interface PollResult {
+  outcome: PollOutcome
+  error?: string
+}
+
+export interface PollOptions {
+  fetchFn?: (url: string) => Promise<Response>
+  sleepFn?: (ms: number) => Promise<void>
+  onProgress?: (snap: SyncProgressSnapshot) => void
+  intervalMs?: number
+  maxAttempts?: number
+}
+
+const DEFAULT_INTERVAL_MS = 1000
+// 3 minutes at 1s cadence — long enough for a normal run, short enough
+// that a zombie invocation gives up instead of polling forever.
+const DEFAULT_MAX_ATTEMPTS = 180
+
+export async function pollSyncUntilTerminal(
+  syncId: string,
+  opts: PollOptions = {},
+): Promise<PollResult> {
+  const fetchFn = opts.fetchFn ?? fetch
+  const sleepFn = opts.sleepFn ?? ((ms) => new Promise((r) => setTimeout(r, ms)))
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+  const url = `/api/sync/progress?id=${encodeURIComponent(syncId)}`
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await sleepFn(intervalMs)
+    try {
+      const res = await fetchFn(url)
+      if (!res.ok) continue
+      const data = (await res.json()) as SyncProgressSnapshot
+      opts.onProgress?.(data)
+      if (data.stage === 'complete') return { outcome: 'complete' }
+      if (data.stage === 'error') return { outcome: 'error', error: data.error ?? 'Sync failed' }
+    } catch {
+      // Transient network error — keep polling.
+    }
+  }
+
+  return { outcome: 'timeout' }
+}

--- a/lib/sync-run-status.ts
+++ b/lib/sync-run-status.ts
@@ -1,0 +1,15 @@
+import type { SyncLog } from '@/types/database'
+
+export type StatusTone = 'success' | 'error' | 'warn'
+
+export interface SyncRunStatus {
+  label: string
+  tone: StatusTone
+}
+
+export function syncRunStatusLabel(log: SyncLog): SyncRunStatus {
+  if (log.error) return { label: log.error, tone: 'error' }
+  if (log.stage === 'complete') return { label: 'All stages green', tone: 'success' }
+  if (log.stage === 'error') return { label: 'Sync failed', tone: 'error' }
+  return { label: 'Run did not finish', tone: 'warn' }
+}


### PR DESCRIPTION
## Summary
Three tightly-coupled fixes so a sync run that crashes mid-pipeline doesn't leave the UI permanently confused.

**Slice 2 — Inngest terminal state** (`lib/inngest/`)
When the Inngest function times out or crashes mid-run, the last write to `sync_log.stage` was whatever `onProgress` set ("analyzing"). Inngest's retry policy then re-ran the whole pipeline from `sync-start`, and after retries were exhausted no code path wrote a terminal stage. Added `markSyncFailed` helper and an Inngest `onFailure` handler that guarantees `stage='error'` + `completed_at` are set whenever the function gives up.

**Slice 3 — client polling cap** (`lib/poll-sync-progress.ts`)
Extracted the `/sync` and `/onboard` polling loops into `pollSyncUntilTerminal` with a 3-minute cap. On timeout both pages show a friendly "taking longer than expected" message instead of polling forever.

**Slice 4 — history UI label** (`lib/sync-run-status.ts`)
History row said "All stages green" for any run with `error=null`, including stuck runs. Extracted `syncRunStatusLabel` which returns success / error / warn based on both `stage` and `error`; stuck runs now render "Run did not finish" with an amber dot.

## Test plan
- [x] `npx jest` — 1036 pass (3 unrelated-worktree failures pre-existing)
- [x] TDD for each slice — red → green
- [ ] After merge: trigger a sync in prod, confirm history row tone/label reflects actual stage, confirm client stops polling on stuck runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)