### PR TITLE
Show last successful sync timestamp, not last-run timestamp

### DIFF
--- a/app/sync/page.tsx
+++ b/app/sync/page.tsx
@@ -101,6 +101,11 @@ export default function SyncPage() {
     ? lastStatus.tone === 'success' ? 'OK' : lastStatus.tone === 'warn' ? 'Stuck' : 'Error'
     : '—'
 
+  const lastSuccessful = history.find((h) => syncRunStatusLabel(h).tone === 'success')
+  const lastSuccessfulLabel = lastSuccessful
+    ? new Date(lastSuccessful.completed_at ?? lastSuccessful.started_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+    : '—'
+
   return (
     <>
       <Nav />
@@ -145,7 +150,7 @@ export default function SyncPage() {
           <Stat big={status?.games_processed ?? '—'} label="Games imported (last run)" mono />
           <Stat big={status?.cards_created ?? '—'} label="Cards created (last run)" mono />
           <Stat big={lastStatusStat} label="Last run status" mono />
-          <Stat big={lastRun} label="Last successful run" mono />
+          <Stat big={lastSuccessfulLabel} label="Last successful run" mono />
         </div>
 
         {/* Pipeline diagram */}


### PR DESCRIPTION
## Summary
Final cleanup on the /sync stats row. The "Last successful run" tile used \`lastRun\` (timestamp of the most recent log) regardless of whether that run actually succeeded. Now it finds the most recent history row with success tone and uses that timestamp, falling back to em dash.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] After merge: confirm tile shows em dash or a real-success timestamp in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)