### PR TITLE
Plan E: Make Inngest sync pipeline actually complete (fix #67)

### DIFF
--- a/__tests__/lib/inngest-sync-games-handler.test.ts
+++ b/__tests__/lib/inngest-sync-games-handler.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+
+interface ChainableDb {
+  from: jest.Mock
+  update: jest.Mock
+  eq: jest.Mock
+}
+function makeChainableDb(): ChainableDb {
+  const chain = {} as ChainableDb
+  chain.from = jest.fn(() => chain)
+  chain.update = jest.fn(() => chain)
+  chain.eq = jest.fn(async () => ({ data: null, error: null }))
+  return chain
+}
+
+const fakeDb = makeChainableDb()
+
+jest.mock('@/lib/supabase-service', () => ({
+  createServiceClient: jest.fn(() => fakeDb),
+}))
+
+jest.mock('@/lib/sync-orchestrator', () => ({
+  runSync: jest.fn(),
+}))
+
+jest.mock('@/lib/sync-step-logger', () => ({
+  makeSupabaseStepLogger: jest.fn(() => 'STEP_LOGGER'),
+}))
+
+jest.mock('@/lib/inngest/terminal-state', () => ({
+  markSyncFailed: jest.fn(),
+}))
+
+import { syncGamesHandler } from '@/lib/inngest/functions'
+import { runSync } from '@/lib/sync-orchestrator'
+
+const mockedRunSync = runSync as jest.MockedFunction<typeof runSync>
+
+describe('syncGamesHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedRunSync.mockResolvedValue({ gamesProcessed: 3, cardsCreated: 5, errors: [] })
+  })
+
+  it('forwards the Inngest step object into runSync so per-game work is memoized across retries', async () => {
+    const step = {
+      run: jest.fn(async (_id: string, fn: () => unknown) => await fn()),
+    }
+
+    await syncGamesHandler({
+      event: {
+        data: {
+          syncLogId: 'log-1',
+          userId: 'user-1',
+          username: 'alice',
+          mode: 'incremental',
+        },
+      },
+      step,
+    } as unknown as Parameters<typeof syncGamesHandler>[0])
+
+    expect(mockedRunSync).toHaveBeenCalledTimes(1)
+    const [, opts] = mockedRunSync.mock.calls[0]
+    expect(opts.step).toBe(step)
+    expect(opts.username).toBe('alice')
+    expect(opts.userId).toBe('user-1')
+  })
+})

--- a/__tests__/lib/sync-orchestrator.test.ts
+++ b/__tests__/lib/sync-orchestrator.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { runSync, type SyncLogger, type StepLogger, type SyncStepEvent } from '@/lib/sync-orchestrator'
+import { runSync, type SyncLogger, type StepLogger, type SyncStepEvent, type StepRunner } from '@/lib/sync-orchestrator'
 import { makeMockDb } from '@/__tests__/helpers/mock-db'
 
 jest.mock('@/lib/stockfish-analyzer', () => ({
@@ -355,6 +355,72 @@ describe('runSync', () => {
       expect(fetchEnd.errorCode).toBe('FETCH_FAILED')
       // sync-end should NOT fire when the fetcher threw — we never got past fetch.
       expect(events.find((e) => e.step === 'sync-end')).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // step runner — Inngest-style memoization of expensive phases
+  // -------------------------------------------------------------------------
+
+  describe('step runner', () => {
+    function makeStepSpy(): { step: StepRunner; calls: Array<{ id: string; hit: 'miss' | 'hit' }>; cache: Map<string, unknown> } {
+      const cache = new Map<string, unknown>()
+      const calls: Array<{ id: string; hit: 'miss' | 'hit' }> = []
+      const step: StepRunner = {
+        async run<T>(id: string, fn: () => Promise<T> | T): Promise<T> {
+          if (cache.has(id)) {
+            calls.push({ id, hit: 'hit' })
+            return cache.get(id) as T
+          }
+          calls.push({ id, hit: 'miss' })
+          const value = await fn()
+          cache.set(id, value)
+          return value
+        },
+      }
+      return { step, calls, cache }
+    }
+
+    it('wraps the fetch-archives phase in a single step.run when a step runner is supplied', async () => {
+      const { db } = makeMockDb()
+      const { step, calls } = makeStepSpy()
+      const fetcher = jest.fn(async () => ['<pgn>'])
+
+      mockedParse.mockReturnValue([{ fen: 'FEN', movePlayed: 'e4' }])
+      mockedGenerate.mockResolvedValue({ created: 1, skipped: 0 })
+
+      await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: fetcher,
+        step,
+      })
+
+      const fetchStepCalls = calls.filter((c) => c.id === 'fetch-archives')
+      expect(fetchStepCalls).toEqual([{ id: 'fetch-archives', hit: 'miss' }])
+      expect(fetcher).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns memoized fetch-archives output on replay without re-invoking the fetcher', async () => {
+      const { db } = makeMockDb()
+      const { step, cache } = makeStepSpy()
+      cache.set('fetch-archives', ['<cached-pgn>'])
+      const fetcher = jest.fn(async () => ['<fresh-pgn>'])
+
+      mockedParse.mockReturnValue([{ fen: 'FEN', movePlayed: 'e4' }])
+      mockedGenerate.mockResolvedValue({ created: 1, skipped: 0 })
+
+      const result = await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: fetcher,
+        step,
+      })
+
+      expect(fetcher).not.toHaveBeenCalled()
+      expect(result.gamesProcessed).toBe(1)
     })
   })
 })

--- a/__tests__/lib/sync-orchestrator.test.ts
+++ b/__tests__/lib/sync-orchestrator.test.ts
@@ -402,6 +402,76 @@ describe('runSync', () => {
       expect(fetcher).toHaveBeenCalledTimes(1)
     })
 
+    it('wraps each game in its own process-game-${i} step when a step runner is supplied', async () => {
+      const { db } = makeMockDb()
+      const { step, calls } = makeStepSpy()
+
+      mockedParse.mockReturnValue([{ fen: 'FEN', movePlayed: 'e4' }])
+      mockedGenerate.mockResolvedValue({ created: 1, skipped: 0 })
+
+      await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: async () => ['<pgn-1>', '<pgn-2>', '<pgn-3>'],
+        step,
+      })
+
+      const gameStepIds = calls.filter((c) => c.id.startsWith('process-game-')).map((c) => c.id)
+      expect(gameStepIds).toEqual(['process-game-0', 'process-game-1', 'process-game-2'])
+    })
+
+    it('skips re-executing per-game work when a process-game step result is already memoized', async () => {
+      const { db } = makeMockDb()
+      const { step, cache } = makeStepSpy()
+      cache.set('fetch-archives', ['<pgn-0>', '<pgn-1>'])
+      cache.set('process-game-0', { cardsCreated: 7 })
+
+      mockedParse.mockReturnValue([{ fen: 'FEN', movePlayed: 'e4' }])
+      mockedGenerate.mockResolvedValue({ created: 3, skipped: 0 })
+
+      const result = await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: async () => ['ignored'],
+        step,
+      })
+
+      // game 0 hit cache → parser/generator only ran for game 1
+      expect(mockedParse).toHaveBeenCalledTimes(1)
+      expect(mockedGenerate).toHaveBeenCalledTimes(1)
+      // cardsCreated = 7 (cached) + 3 (fresh)
+      expect(result.cardsCreated).toBe(10)
+      expect(result.gamesProcessed).toBe(2)
+    })
+
+    it('captures per-game errors inside the step without propagating to the step runner', async () => {
+      const { db } = makeMockDb()
+      const { step, calls } = makeStepSpy()
+
+      let parseCall = 0
+      mockedParse.mockImplementation(() => {
+        parseCall++
+        if (parseCall === 1) throw new Error('bad pgn')
+        return [{ fen: 'FEN', movePlayed: 'e4' }]
+      })
+      mockedGenerate.mockResolvedValue({ created: 2, skipped: 0 })
+
+      const result = await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: async () => ['<bad>', '<good>'],
+        step,
+      })
+
+      // both game steps were attempted (neither propagated out of step.run)
+      expect(calls.filter((c) => c.id === 'process-game-0')).toHaveLength(1)
+      expect(calls.filter((c) => c.id === 'process-game-1')).toHaveLength(1)
+      expect(result).toEqual({ gamesProcessed: 1, cardsCreated: 2, errors: ['bad pgn'] })
+    })
+
     it('returns memoized fetch-archives output on replay without re-invoking the fetcher', async () => {
       const { db } = makeMockDb()
       const { step, cache } = makeStepSpy()

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -2,6 +2,12 @@ import { serve } from 'inngest/next'
 import { inngest } from '@/lib/inngest/client'
 import { syncGamesFunction } from '@/lib/inngest/functions'
 
+// Each Inngest step runs as its own invocation of this handler. A single
+// game's Stockfish analysis needs well more than Vercel's default budget —
+// 300s (5 min, Vercel Pro ceiling) gives ample headroom per step while the
+// step.run memoization keeps the whole sync resumable.
+export const maxDuration = 300
+
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [syncGamesFunction],

--- a/lib/inngest/functions.ts
+++ b/lib/inngest/functions.ts
@@ -1,12 +1,82 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { inngest } from './client'
-import { runSync, type SyncProgress } from '@/lib/sync-orchestrator'
+import { runSync, type SyncProgress, type StepRunner } from '@/lib/sync-orchestrator'
 import { createServiceClient } from '@/lib/supabase-service'
 import { makeSupabaseStepLogger } from '@/lib/sync-step-logger'
 import { markSyncFailed } from './terminal-state'
 
 export interface SyncGamesDeps {
   db?: SupabaseClient
+}
+
+interface SyncGamesHandlerArgs {
+  event: {
+    data: {
+      syncLogId: string
+      userId: string
+      username: string
+      mode: 'historical' | 'incremental'
+    }
+  }
+  step: StepRunner
+}
+
+/**
+ * The handler body for the Inngest sync-games function. Extracted as a named
+ * export so unit tests can drive it directly with a stub `step` without
+ * needing the Inngest runtime.
+ */
+export async function syncGamesHandler({ event, step }: SyncGamesHandlerArgs) {
+  const { syncLogId, userId, username, mode } = event.data
+
+  const db: SupabaseClient = createServiceClient()
+
+  await step.run('mark-fetching', async () => {
+    await db
+      .from('sync_log')
+      .update({ stage: 'fetching' })
+      .eq('id', syncLogId)
+  })
+
+  try {
+    const result = await runSync(mode, {
+      username,
+      userId,
+      db,
+      step,
+      stepLogger: makeSupabaseStepLogger(db, syncLogId),
+      onProgress: async (p: SyncProgress) => {
+        await db
+          .from('sync_log')
+          .update({
+            stage: p.stage,
+            games_total: p.gamesTotal,
+            games_processed: p.gamesProcessed,
+            cards_created: p.cardsCreated,
+          })
+          .eq('id', syncLogId)
+      },
+    })
+
+    await step.run('mark-complete', async () => {
+      await db
+        .from('sync_log')
+        .update({
+          stage: 'complete',
+          completed_at: new Date().toISOString(),
+          games_processed: result.gamesProcessed,
+          cards_created: result.cardsCreated,
+          error: result.errors.length > 0 ? result.errors.join('; ') : null,
+        })
+        .eq('id', syncLogId)
+    })
+
+    return result
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    await markSyncFailed(db, syncLogId, message)
+    throw err
+  }
 }
 
 /**
@@ -32,60 +102,5 @@ export const syncGamesFunction = inngest.createFunction(
       await markSyncFailed(db, syncLogId, message)
     },
   },
-  async ({ event, step }) => {
-    const { syncLogId, userId, username, mode } = event.data as {
-      syncLogId: string
-      userId: string
-      username: string
-      mode: 'historical' | 'incremental'
-    }
-
-    const db: SupabaseClient = createServiceClient()
-
-    await step.run('mark-fetching', async () => {
-      await db
-        .from('sync_log')
-        .update({ stage: 'fetching' })
-        .eq('id', syncLogId)
-    })
-
-    try {
-      const result = await runSync(mode, {
-        username,
-        userId,
-        db,
-        stepLogger: makeSupabaseStepLogger(db, syncLogId),
-        onProgress: async (p: SyncProgress) => {
-          await db
-            .from('sync_log')
-            .update({
-              stage: p.stage,
-              games_total: p.gamesTotal,
-              games_processed: p.gamesProcessed,
-              cards_created: p.cardsCreated,
-            })
-            .eq('id', syncLogId)
-        },
-      })
-
-      await step.run('mark-complete', async () => {
-        await db
-          .from('sync_log')
-          .update({
-            stage: 'complete',
-            completed_at: new Date().toISOString(),
-            games_processed: result.gamesProcessed,
-            cards_created: result.cardsCreated,
-            error: result.errors.length > 0 ? result.errors.join('; ') : null,
-          })
-          .eq('id', syncLogId)
-      })
-
-      return result
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      await markSyncFailed(db, syncLogId, message)
-      throw err
-    }
-  },
+  syncGamesHandler as unknown as Parameters<typeof inngest.createFunction>[1],
 )

--- a/lib/sync-orchestrator.ts
+++ b/lib/sync-orchestrator.ts
@@ -270,48 +270,63 @@ export async function runSync(
 
   for (let gameIndex = 0; gameIndex < pgns.length; gameIndex++) {
     const pgn = pgns[gameIndex]
-    let gameUrl: string | null = null
-    try {
-      const headers = await runStep(
-        stepLogger,
-        { step: 'parse-headers', gameIndex },
-        () => parsePgnHeaders(pgn),
-      )
-      gameUrl = headers.url ?? null
 
-      const positions = await runStep(
-        stepLogger,
-        { step: 'parse-positions', gameUrl, gameIndex },
-        () => parseGame(pgn),
-      )
+    // Each game's work is a single Inngest step so retries resume at the
+    // failed game instead of re-running earlier games, and so each game
+    // gets its own fresh Vercel invocation budget.
+    const gameResult = await runInStep(`process-game-${gameIndex}`, async () => {
+      let gameUrl: string | null = null
+      try {
+        const headers = await runStep(
+          stepLogger,
+          { step: 'parse-headers', gameIndex },
+          () => parsePgnHeaders(pgn),
+        )
+        gameUrl = headers.url ?? null
 
-      const gameId = await runStep(
-        stepLogger,
-        { step: 'ensure-game-row', gameUrl, gameIndex },
-        () => ensureGameRow(db, userId, pgn, headers),
-      )
+        const positions = await runStep(
+          stepLogger,
+          { step: 'parse-positions', gameUrl, gameIndex },
+          () => parseGame(pgn),
+        )
 
-      const analyses = await runStep(
-        stepLogger,
-        {
-          step: 'analyze',
-          gameUrl,
-          gameIndex,
-          detailsOnOk: { positions: positions.length },
-        },
-        () => analyzeGame(positions, engineFactory),
-      )
+        const gameId = await runStep(
+          stepLogger,
+          { step: 'ensure-game-row', gameUrl, gameIndex },
+          () => ensureGameRow(db, userId, pgn, headers),
+        )
 
-      const result = await runStep(
-        stepLogger,
-        { step: 'generate-cards', gameUrl, gameIndex },
-        () => generateCards(analyses, db, gameId),
-      )
+        const analyses = await runStep(
+          stepLogger,
+          {
+            step: 'analyze',
+            gameUrl,
+            gameIndex,
+            detailsOnOk: { positions: positions.length },
+          },
+          () => analyzeGame(positions, engineFactory),
+        )
 
+        const result = await runStep(
+          stepLogger,
+          { step: 'generate-cards', gameUrl, gameIndex },
+          () => generateCards(analyses, db, gameId),
+        )
+
+        return { cardsCreated: result.created }
+      } catch (err) {
+        // Swallow per-game errors inside the step so one bad game doesn't
+        // bubble up and fail the whole Inngest function. Callers aggregate
+        // these into `errors` below.
+        return { error: formatError(err) }
+      }
+    }) as { cardsCreated?: number; error?: string }
+
+    if (gameResult.error !== undefined) {
+      errors.push(gameResult.error)
+    } else {
       gamesProcessed++
-      cardsCreated += result.created
-    } catch (err) {
-      errors.push(formatError(err))
+      cardsCreated += gameResult.cardsCreated ?? 0
     }
 
     await onProgress?.({

--- a/lib/sync-orchestrator.ts
+++ b/lib/sync-orchestrator.ts
@@ -60,6 +60,16 @@ export interface SyncStepEvent {
  */
 export type StepLogger = (event: SyncStepEvent) => Promise<void>
 
+/**
+ * Minimal shape of Inngest's `step` object: run a named callback whose result
+ * is memoized across invocations. When present, the orchestrator wraps
+ * expensive phases in it so Inngest retries resume from where they left off
+ * instead of restarting the whole pipeline.
+ */
+export interface StepRunner {
+  run<T>(id: string, fn: () => Promise<T> | T): Promise<T>
+}
+
 export interface SyncOptions {
   username: string
   userId: string
@@ -69,6 +79,7 @@ export interface SyncOptions {
   syncLogger?: SyncLogger
   onProgress?: (progress: SyncProgress) => Promise<void> | void
   stepLogger?: StepLogger
+  step?: StepRunner
 }
 
 /**
@@ -204,7 +215,9 @@ export async function runSync(
   mode: 'historical' | 'incremental',
   options: SyncOptions,
 ): Promise<SyncResult> {
-  const { username, userId, db, gamesFetcher, engineFactory, syncLogger, onProgress, stepLogger } = options
+  const { username, userId, db, gamesFetcher, engineFactory, syncLogger, onProgress, stepLogger, step } = options
+  const runInStep = <T,>(id: string, fn: () => Promise<T> | T): Promise<T> =>
+    step ? step.run(id, fn) : Promise.resolve().then(fn)
 
   const logId = await syncLogger?.logStart(mode)
 
@@ -215,34 +228,34 @@ export async function runSync(
   const fetcher = gamesFetcher ?? ((u, m) => fetchGames(u, m))
   await onProgress?.({ stage: 'fetching', gamesProcessed: 0, gamesTotal: 0, cardsCreated: 0 })
 
-  if (stepLogger) {
-    await stepLogger({ step: 'fetch-archives-start', status: 'ok', details: { mode } })
-  }
-
-  let pgns: string[]
-  try {
-    pgns = await fetcher(username, mode)
-  } catch (err) {
+  const pgns = await runInStep('fetch-archives', async () => {
     if (stepLogger) {
-      const { message, code, details } = formatErrorStructured(err)
-      await stepLogger({
-        step: 'fetch-archives-end',
-        status: 'error',
-        error: message,
-        errorCode: code,
-        details,
-      })
+      await stepLogger({ step: 'fetch-archives-start', status: 'ok', details: { mode } })
     }
-    throw err
-  }
-
-  if (stepLogger) {
-    await stepLogger({
-      step: 'fetch-archives-end',
-      status: 'ok',
-      details: { count: pgns.length },
-    })
-  }
+    try {
+      const list = await fetcher(username, mode)
+      if (stepLogger) {
+        await stepLogger({
+          step: 'fetch-archives-end',
+          status: 'ok',
+          details: { count: list.length },
+        })
+      }
+      return list
+    } catch (err) {
+      if (stepLogger) {
+        const { message, code, details } = formatErrorStructured(err)
+        await stepLogger({
+          step: 'fetch-archives-end',
+          status: 'error',
+          error: message,
+          errorCode: code,
+          details,
+        })
+      }
+      throw err
+    }
+  })
 
   let gamesProcessed = 0
   let cardsCreated = 0


### PR DESCRIPTION
## Summary
Fixes the root cause diagnosed in #67: every prod sync was restarting the whole pipeline on each Inngest retry, so `games_processed` stayed at 0.

- Add a minimal `StepRunner` option on `runSync` and wrap the fetch-archives phase + each per-game chain (parse → ensure → analyze → generate) in `step.run` when one is supplied. Each game gets its own fresh Vercel invocation budget, and retries resume from the failed game instead of `sync-start`.
- Forward the Inngest `step` object from `syncGamesHandler` into `runSync`. Per-game errors are caught inside the step so a single bad game doesn't abort the run.
- Set `maxDuration = 300` on `/api/inngest/route` (Vercel Pro ceiling) as headroom per step.

Plan C's `onFailure` handler (#64) is untouched and should fire far less often once runs actually finish.

## Test plan
- [x] New unit tests on `sync-orchestrator`: `step.run('fetch-archives')`, `step.run('process-game-${i}')` per game, replay-from-cache, per-game error capture inside steps
- [x] New `syncGamesHandler` test confirms the Inngest `step` is forwarded into `runSync`
- [x] Full jest suite passes (367 tests)
- [ ] Smoke test in prod: trigger sync on chess-game-reviewer.vercel.app/sync, confirm `games_processed > 0` and `cards_created > 0` in audit UI; audit page shows one continuous pipeline (not 5× duplicated `fetch-archives`)

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)