### PR TITLE
Cap Stockfish to 500ms per position (fix #67 part 2)

### DIFF
--- a/__tests__/lib/stockfish-analyzer.test.ts
+++ b/__tests__/lib/stockfish-analyzer.test.ts
@@ -199,6 +199,36 @@ describe('analyzeGame', () => {
     })
   })
 
+  describe('engine command budget', () => {
+    it('uses movetime (not depth) so each eval has a hard per-position time cap', async () => {
+      const commands: string[] = []
+      const engine: () => UciEngine = () => {
+        const e: UciEngine = {
+          onmessage: null,
+          postMessage(cmd: string) {
+            commands.push(cmd)
+            if (cmd.startsWith('go')) {
+              setTimeout(() => {
+                e.onmessage?.('info depth 12 score cp 20 pv e2e4')
+                e.onmessage?.('bestmove e2e4')
+              }, 0)
+            }
+          },
+        }
+        return e
+      }
+
+      const startFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+      await analyzeGame([{ fen: startFen, movePlayed: 'e4' }], engine)
+
+      const goCommands = commands.filter((c) => c.startsWith('go'))
+      expect(goCommands.length).toBeGreaterThan(0)
+      for (const cmd of goCommands) {
+        expect(cmd).toMatch(/^go movetime \d+$/)
+      }
+    })
+  })
+
   describe('fixture position sequences', () => {
     // Scenario 1: blunder — one move loses 250+ CPL
     it('scenario 1: blunder move produces high CPL (>200)', async () => {

--- a/lib/stockfish-analyzer.ts
+++ b/lib/stockfish-analyzer.ts
@@ -42,6 +42,12 @@ function parsePv(line: string): string[] {
   return match[1].trim().split(/\s+/)
 }
 
+// Per-position time cap for Stockfish. A full game (~160 evals) at 500ms is
+// ~80s, well inside our Inngest step budget; `depth 15` was open-ended and
+// routinely exceeded 5 minutes per game on Vercel, causing the sync pipeline
+// to time out before writing a single analyze row (see issue #67).
+const DEFAULT_MOVETIME_MS = 500
+
 async function evaluateFen(engine: UciEngine, fen: string): Promise<EvalResult> {
   return new Promise((resolve) => {
     let lastScore = 0
@@ -60,7 +66,7 @@ async function evaluateFen(engine: UciEngine, fen: string): Promise<EvalResult> 
       }
     }
     engine.postMessage(`position fen ${fen}`)
-    engine.postMessage('go depth 15')
+    engine.postMessage(`go movetime ${DEFAULT_MOVETIME_MS}`)
   })
 }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #71. Prod smoke test showed per-game step was still timing out because \`go depth 15\` on a full live game exceeds 5 minutes on Vercel serverless — above the 300s step budget PR #71 set. Inngest then retries the \`process-game-0\` step in a tight loop and the sync still finishes with \`games_processed=0\`.

Swap \`go depth 15\` → \`go movetime 500\` in \`lib/stockfish-analyzer.ts\`. Each eval now has a hard 500ms cap. A 160-eval game takes ~80s (well under 300s), and blunder/mistake classification is unaffected at this quality level.

## Test plan
- [x] New unit test asserting every \`go\` command uses \`movetime\` (not \`depth\`)
- [x] Full jest suite still green (368 tests)
- [ ] Smoke test in prod: trigger sync on chess-game-reviewer.vercel.app/sync, confirm \`games_processed > 0\`, \`cards_created > 0\`, and audit page shows \`analyze:ok\` + \`generate-cards:ok\` rows for each game

🤖 Generated with [Claude Code](https://claude.com/claude-code)