### PR TITLE
Diagnostic: hard-timeout Stockfish init + per-eval so hang point is visible

### DIFF
--- a/__tests__/lib/stockfish-analyzer.test.ts
+++ b/__tests__/lib/stockfish-analyzer.test.ts
@@ -199,6 +199,33 @@ describe('analyzeGame', () => {
     })
   })
 
+  describe('hang detection', () => {
+    it('throws engine-init-timeout when the engine factory never resolves', async () => {
+      const neverResolvingFactory = () => new Promise<UciEngine>(() => { /* hang */ })
+      await expect(
+        analyzeGame(
+          [{ fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1', movePlayed: 'e4' }],
+          neverResolvingFactory,
+          { engineInitTimeoutMs: 50, evalTimeoutMs: 5000 },
+        ),
+      ).rejects.toThrow(/engine-init/)
+    })
+
+    it('throws eval-timeout when the engine never emits bestmove', async () => {
+      const hangingEngine: () => UciEngine = () => ({
+        onmessage: null,
+        postMessage() { /* never respond */ },
+      })
+      await expect(
+        analyzeGame(
+          [{ fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1', movePlayed: 'e4' }],
+          hangingEngine,
+          { engineInitTimeoutMs: 5000, evalTimeoutMs: 50 },
+        ),
+      ).rejects.toThrow(/eval/)
+    })
+  })
+
   describe('engine command budget', () => {
     it('uses movetime (not depth) so each eval has a hard per-position time cap', async () => {
       const commands: string[] = []

--- a/lib/stockfish-analyzer.ts
+++ b/lib/stockfish-analyzer.ts
@@ -48,6 +48,26 @@ function parsePv(line: string): string[] {
 // to time out before writing a single analyze row (see issue #67).
 const DEFAULT_MOVETIME_MS = 500
 
+export interface AnalyzeOptions {
+  /** Hard cap on engine-factory resolution. Default 30s. */
+  engineInitTimeoutMs?: number
+  /** Hard cap on a single position evaluation. Default 3s. */
+  evalTimeoutMs?: number
+}
+
+const DEFAULT_ENGINE_INIT_TIMEOUT_MS = 30_000
+const DEFAULT_EVAL_TIMEOUT_MS = 3_000
+
+function withTimeout<T>(label: string, ms: number, p: Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label} exceeded ${ms}ms`)), ms)
+    p.then(
+      (v) => { clearTimeout(t); resolve(v) },
+      (e) => { clearTimeout(t); reject(e) },
+    )
+  })
+}
+
 async function evaluateFen(engine: UciEngine, fen: string): Promise<EvalResult> {
   return new Promise((resolve) => {
     let lastScore = 0
@@ -96,6 +116,7 @@ function uciToSan(fen: string, uciMove: string): string | null {
 export async function analyzeGame(
   positions: GamePosition[],
   engineFactory: () => UciEngine | Promise<UciEngine> = createDefaultEngine,
+  options: AnalyzeOptions = {},
 ): Promise<PositionAnalysis[]> {
   if (typeof window !== 'undefined') {
     throw new Error('Stockfish analyzer must only run server-side')
@@ -103,20 +124,27 @@ export async function analyzeGame(
 
   if (positions.length === 0) return []
 
-  const engine = await engineFactory()
+  const engineInitTimeoutMs = options.engineInitTimeoutMs ?? DEFAULT_ENGINE_INIT_TIMEOUT_MS
+  const evalTimeoutMs = options.evalTimeoutMs ?? DEFAULT_EVAL_TIMEOUT_MS
+
+  const engine = await withTimeout(
+    'engine-init',
+    engineInitTimeoutMs,
+    Promise.resolve(engineFactory()),
+  )
   const results: PositionAnalysis[] = []
 
   for (let i = 0; i < positions.length; i++) {
     const { fen, movePlayed } = positions[i]
 
-    const before = await evaluateFen(engine, fen)
+    const before = await withTimeout(`eval[${i}:before]`, evalTimeoutMs, evaluateFen(engine, fen))
 
     const nextFen =
       i + 1 < positions.length
         ? positions[i + 1].fen
         : fenAfterMove(fen, movePlayed)
 
-    const after = await evaluateFen(engine, nextFen)
+    const after = await withTimeout(`eval[${i}:after]`, evalTimeoutMs, evaluateFen(engine, nextFen))
     const cpl = Math.max(0, before.score + after.score)
     const moveCount = legalMoveCount(fen)
     const bestMoveSan = uciToSan(fen, before.bestMove) ?? before.bestMove


### PR DESCRIPTION
## Summary
Prod syncs after PR #71 + #72 still hang at \`analyze\` with no audit row — the 5-minute stall pattern is consistent with \`createDefaultEngine\` silently hanging on Stockfish WASM init under Vercel's Node runtime (Emscripten builds sometimes expect Worker/browser globals). Without a timeout, the hang is invisible.

Wrap both phases in hard timeouts so the hang location becomes a real error row instead of a silent stall:

- **engine-init**: 30s. Throws \`engine-init exceeded 30000ms\` if the factory Promise never resolves.
- **per-eval**: 3s. Throws if a single \`go movetime\` call never emits \`bestmove\`.

After this deploys, one more sync will produce an \`analyze:error\` row in \`sync_step_log\` naming exactly which phase hung, which will tell us the right permanent fix (swap Stockfish variant, switch to hosted analysis API, etc.).

## Test plan
- [x] New unit tests covering both timeout paths (engine-init hang, eval hang)
- [x] Full jest suite passes (370 tests)
- [ ] Post-deploy smoke test: trigger sync, observe the specific error message in \`sync_step_log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)