### PR TITLE
Plan F: Move sync pipeline to Fly.io worker + chess.com hardening (#74, fixes #67)

### DIFF
--- a/__tests__/api/inngest-route.test.ts
+++ b/__tests__/api/inngest-route.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment node
+ */
+
+// Slice 6 (#74): once the persistent worker is live, the Vercel /api/inngest
+// route must no longer claim to handle `sync/run`. Otherwise Inngest may
+// still route jobs to Vercel — where Stockfish cold-loads freeze the event
+// loop (the exact bug we moved to a worker to fix, issue #67).
+
+import { vercelInngestFunctions } from '@/app/api/inngest/route'
+
+describe('Vercel /api/inngest route', () => {
+  it('no longer registers any sync-pipeline functions (delegated to the Fly.io worker)', () => {
+    expect(vercelInngestFunctions).toEqual([])
+  })
+})

--- a/__tests__/api/inngest-route.test.ts
+++ b/__tests__/api/inngest-route.test.ts
@@ -7,7 +7,7 @@
 // still route jobs to Vercel — where Stockfish cold-loads freeze the event
 // loop (the exact bug we moved to a worker to fix, issue #67).
 
-import { vercelInngestFunctions } from '@/app/api/inngest/route'
+import { vercelInngestFunctions } from '@/lib/inngest/vercel-functions'
 
 describe('Vercel /api/inngest route', () => {
   it('no longer registers any sync-pipeline functions (delegated to the Fly.io worker)', () => {

--- a/__tests__/lib/chess-com/client.test.ts
+++ b/__tests__/lib/chess-com/client.test.ts
@@ -1,14 +1,22 @@
+/**
+ * @jest-environment node
+ */
 import { fetchMonthlyArchive, ChessComApiError } from '../../../lib/chess-com/client'
 
 const FAKE_PGN_1 = '[Event "Live Chess"]\n1. e4 e5 *'
 const FAKE_PGN_2 = '[Event "Live Chess"]\n1. d4 d5 *'
 
-function mockFetch(status: number, body: unknown) {
-  global.fetch = jest.fn().mockResolvedValue({
+function fakeResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return {
     ok: status >= 200 && status < 300,
     status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
     json: async () => body,
-  })
+  }
+}
+
+function mockFetch(status: number, body: unknown) {
+  global.fetch = jest.fn().mockResolvedValue(fakeResponse(status, body)) as unknown as typeof fetch
 }
 
 afterEach(() => {
@@ -30,15 +38,6 @@ describe('fetchMonthlyArchive', () => {
     jest.useRealTimers()
   })
 
-  it('throws ChessComApiError with statusCode on 429 (rate limited)', async () => {
-    mockFetch(429, {})
-
-    await expect(fetchMonthlyArchive('testuser', 2024, 3)).rejects.toThrow(ChessComApiError)
-    await expect(fetchMonthlyArchive('testuser', 2024, 3)).rejects.toMatchObject({
-      statusCode: 429,
-    })
-  })
-
   it('throws ChessComApiError with statusCode on 500', async () => {
     mockFetch(500, {})
 
@@ -48,22 +47,36 @@ describe('fetchMonthlyArchive', () => {
     })
   })
 
-  it('returns empty array for months with no games', async () => {
+  it('returns empty pgns for months with no games', async () => {
     mockFetch(200, { games: [] })
 
     const result = await fetchMonthlyArchive('testuser', 2024, 1)
 
-    expect(result).toEqual([])
+    expect(result).toEqual({
+      status: 200,
+      pgns: [],
+      etag: null,
+      lastModified: null,
+    })
   })
 
-  it('fetches a single archive and returns parsed PGN array', async () => {
-    mockFetch(200, {
-      games: [{ pgn: FAKE_PGN_1 }, { pgn: FAKE_PGN_2 }],
-    })
+  it('fetches a single archive and returns parsed PGN array plus cache headers', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      fakeResponse(
+        200,
+        { games: [{ pgn: FAKE_PGN_1 }, { pgn: FAKE_PGN_2 }] },
+        { etag: '"v1"', 'last-modified': 'Mon, 01 Apr 2024 00:00:00 GMT' },
+      ),
+    ) as unknown as typeof fetch
 
     const result = await fetchMonthlyArchive('testuser', 2024, 3)
 
-    expect(result).toEqual([FAKE_PGN_1, FAKE_PGN_2])
+    expect(result).toEqual({
+      status: 200,
+      pgns: [FAKE_PGN_1, FAKE_PGN_2],
+      etag: '"v1"',
+      lastModified: 'Mon, 01 Apr 2024 00:00:00 GMT',
+    })
     expect(global.fetch).toHaveBeenCalledWith(
       'https://api.chess.com/pub/player/testuser/games/2024/03',
       expect.objectContaining({ headers: expect.any(Object) }),

--- a/__tests__/lib/chess-com/etag.test.ts
+++ b/__tests__/lib/chess-com/etag.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+import { fetchMonthlyArchive } from '@/lib/chess-com/client'
+
+function responseOk(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  }
+}
+
+function response304(headers: Record<string, string> = {}) {
+  return {
+    ok: false,
+    status: 304,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => ({}),
+  }
+}
+
+describe('fetchMonthlyArchive — ETag / If-Modified-Since conditional fetch', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('sends If-None-Match when a cached ETag is provided', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      responseOk({ games: [{ pgn: 'P1' }] }, { etag: '"abc123"' }),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await fetchMonthlyArchive('alice', 2024, 3, {
+      cache: { etag: '"abc123"' },
+    })
+
+    const call = fetchMock.mock.calls[0]
+    const headers = call[1].headers as Record<string, string>
+    expect(headers['If-None-Match']).toBe('"abc123"')
+  })
+
+  it('sends If-Modified-Since when a cached Last-Modified is provided', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      responseOk({ games: [] }),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await fetchMonthlyArchive('alice', 2024, 3, {
+      cache: { lastModified: 'Tue, 15 Nov 2024 12:00:00 GMT' },
+    })
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers['If-Modified-Since']).toBe('Tue, 15 Nov 2024 12:00:00 GMT')
+  })
+
+  it('returns status: 304 with no pgns when the archive has not changed', async () => {
+    global.fetch = jest.fn().mockResolvedValue(response304()) as unknown as typeof fetch
+
+    const result = await fetchMonthlyArchive('alice', 2024, 3, {
+      cache: { etag: '"abc123"' },
+    })
+
+    expect(result).toEqual({
+      status: 304,
+      pgns: [],
+      etag: null,
+      lastModified: null,
+    })
+  })
+
+  it('returns the new ETag / Last-Modified on a 200 response so the caller can persist them', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      responseOk(
+        { games: [{ pgn: 'P1' }, { pgn: 'P2' }] },
+        { etag: '"new-tag"', 'last-modified': 'Tue, 20 Feb 2024 00:00:00 GMT' },
+      ),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchMonthlyArchive('alice', 2024, 2)
+
+    expect(result).toEqual({
+      status: 200,
+      pgns: ['P1', 'P2'],
+      etag: '"new-tag"',
+      lastModified: 'Tue, 20 Feb 2024 00:00:00 GMT',
+    })
+  })
+})

--- a/__tests__/lib/chess-com/fetchGames.test.ts
+++ b/__tests__/lib/chess-com/fetchGames.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { fetchGames } from '../../../lib/chess-com/client'
 
 const ARCHIVE_LIST_URL = 'https://api.chess.com/pub/player/testuser/games/archives'
@@ -9,17 +12,20 @@ const PGN_JAN = '[Event "Live Chess"]\n1. e4 e5 *'
 const PGN_FEB = '[Event "Live Chess"]\n1. d4 d5 *'
 const PGN_MAR = '[Event "Live Chess"]\n1. c4 c5 *'
 
-function makeFetchMock(responses: Record<string, { status: number; body: unknown }>) {
-  // fetchGames now passes a second arg (`{ headers: { User-Agent } }`) to every
-  // fetch call. Ignore it here and match by URL alone.
+function fakeResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  }
+}
+
+function makeFetchMock(responses: Record<string, { status: number; body: unknown; headers?: Record<string, string> }>) {
   return jest.fn().mockImplementation((url: string) => {
     const entry = responses[url]
     if (!entry) throw new Error(`Unexpected fetch call: ${url}`)
-    return Promise.resolve({
-      ok: entry.status >= 200 && entry.status < 300,
-      status: entry.status,
-      json: async () => entry.body,
-    })
+    return Promise.resolve(fakeResponse(entry.status, entry.body, entry.headers))
   })
 }
 
@@ -38,7 +44,7 @@ describe('fetchGames — incremental mode', () => {
         status: 200,
         body: { games: [{ pgn: PGN_MAR }] },
       },
-    })
+    }) as unknown as typeof fetch
 
     const result = await fetchGames('testuser', 'incremental')
 
@@ -54,7 +60,7 @@ describe('fetchGames — incremental mode', () => {
         status: 200,
         body: { archives: [] },
       },
-    })
+    }) as unknown as typeof fetch
 
     const result = await fetchGames('testuser', 'incremental')
 
@@ -73,7 +79,7 @@ describe('fetchGames — historical mode', () => {
       [ARCHIVE_JAN]: { status: 200, body: { games: [{ pgn: PGN_JAN }] } },
       [ARCHIVE_FEB]: { status: 200, body: { games: [{ pgn: PGN_FEB }] } },
       [ARCHIVE_MAR]: { status: 200, body: { games: [{ pgn: PGN_MAR }] } },
-    })
+    }) as unknown as typeof fetch
 
     const result = await fetchGames('testuser', 'historical')
 
@@ -87,7 +93,7 @@ describe('fetchGames — historical mode', () => {
         status: 200,
         body: { archives: [] },
       },
-    })
+    }) as unknown as typeof fetch
 
     const result = await fetchGames('testuser', 'historical')
 
@@ -104,7 +110,7 @@ describe('fetchGames — historical mode', () => {
       },
       [ARCHIVE_JAN]: { status: 200, body: { games: [{ pgn: PGN_JAN }] } },
       [ARCHIVE_FEB]: { status: 200, body: { games: [{ pgn: PGN_FEB }] } },
-    })
+    }) as unknown as typeof fetch
 
     const promise = fetchGames('testuser', 'historical', { delayMs: 300 })
 
@@ -115,5 +121,41 @@ describe('fetchGames — historical mode', () => {
     expect(result).toEqual([PGN_JAN, PGN_FEB])
     expect(global.fetch).toHaveBeenCalledTimes(3)
     jest.useRealTimers()
+  })
+
+  it('uses the archive cache to send If-None-Match and skip months that return 304', async () => {
+    global.fetch = makeFetchMock({
+      [ARCHIVE_LIST_URL]: {
+        status: 200,
+        body: { archives: [ARCHIVE_JAN, ARCHIVE_FEB] },
+      },
+      [ARCHIVE_JAN]: { status: 304, body: {} }, // cached — skip
+      [ARCHIVE_FEB]: {
+        status: 200,
+        body: { games: [{ pgn: PGN_FEB }] },
+        headers: { etag: '"feb-new"' },
+      },
+    }) as unknown as typeof fetch
+
+    const archiveCache = {
+      get: jest.fn(async (_y: number, m: number) =>
+        m === 1 ? { etag: '"jan-v1"' } : null,
+      ),
+      set: jest.fn(async () => {}),
+    }
+
+    const result = await fetchGames('testuser', 'historical', { archiveCache })
+
+    expect(result).toEqual([PGN_FEB])
+    // Jan fetched with If-None-Match, got 304
+    const janCall = (global.fetch as unknown as jest.Mock).mock.calls.find(
+      (c) => c[0] === ARCHIVE_JAN,
+    )
+    expect(janCall?.[1].headers['If-None-Match']).toBe('"jan-v1"')
+    // Feb's new etag persisted
+    expect(archiveCache.set).toHaveBeenCalledWith(2024, 2, {
+      etag: '"feb-new"',
+      lastModified: null,
+    })
   })
 })

--- a/__tests__/lib/chess-com/retry.test.ts
+++ b/__tests__/lib/chess-com/retry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+import { fetchMonthlyArchive, ChessComApiError } from '@/lib/chess-com/client'
+
+function responseOk(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  }
+}
+
+function responseStatus(status: number, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => ({}),
+  }
+}
+
+describe('fetchMonthlyArchive — 429 exponential backoff', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('retries on 429 with 1s → 2s → 4s → 8s backoff, then resolves when a retry finally succeeds', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(responseStatus(429))
+      .mockResolvedValueOnce(responseStatus(429))
+      .mockResolvedValueOnce(responseOk({ games: [{ pgn: 'P1' }] }))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const promise = fetchMonthlyArchive('alice', 2024, 3)
+
+    // 1st call: immediate. Then wait 1000ms → 2nd. Then wait 2000ms → 3rd.
+    await jest.advanceTimersByTimeAsync(1000)
+    await jest.advanceTimersByTimeAsync(2000)
+
+    await expect(promise).resolves.toEqual(expect.objectContaining({ pgns: ['P1'] }))
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('gives up after 4 retries and throws ChessComApiError(429)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(responseStatus(429))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const promise = fetchMonthlyArchive('alice', 2024, 3)
+    // Silence unhandled rejection during timer advancement.
+    promise.catch(() => {})
+
+    // 1s + 2s + 4s + 8s = 15s total backoff across 4 retries.
+    await jest.advanceTimersByTimeAsync(1000)
+    await jest.advanceTimersByTimeAsync(2000)
+    await jest.advanceTimersByTimeAsync(4000)
+    await jest.advanceTimersByTimeAsync(8000)
+
+    await expect(promise).rejects.toMatchObject({
+      name: 'ChessComApiError',
+      statusCode: 429,
+    })
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(5)
+    // Constructor reference to silence unused-import lint.
+    expect(ChessComApiError.name).toBe('ChessComApiError')
+  })
+
+  it('does NOT retry non-429 errors (500 bubbles immediately)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(responseStatus(500))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await expect(fetchMonthlyArchive('alice', 2024, 3)).rejects.toMatchObject({
+      statusCode: 500,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/lib/inngest-engine-warmup.test.ts
+++ b/__tests__/lib/inngest-engine-warmup.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ */
+
+interface ChainableDb {
+  from: jest.Mock
+  update: jest.Mock
+  eq: jest.Mock
+}
+function makeChainableDb(): ChainableDb {
+  const chain = {} as ChainableDb
+  chain.from = jest.fn(() => chain)
+  chain.update = jest.fn(() => chain)
+  chain.eq = jest.fn(async () => ({ data: null, error: null }))
+  return chain
+}
+
+const fakeDb = makeChainableDb()
+
+jest.mock('@/lib/supabase-service', () => ({
+  createServiceClient: jest.fn(() => fakeDb),
+}))
+
+jest.mock('@/lib/sync-orchestrator', () => ({
+  runSync: jest.fn(),
+}))
+
+jest.mock('@/lib/sync-step-logger', () => ({
+  makeSupabaseStepLogger: jest.fn(() => 'STEP_LOGGER'),
+}))
+
+jest.mock('@/lib/inngest/terminal-state', () => ({
+  markSyncFailed: jest.fn(),
+}))
+
+import { makeSyncGamesHandler } from '@/lib/inngest/functions'
+import { runSync } from '@/lib/sync-orchestrator'
+
+const mockedRunSync = runSync as jest.MockedFunction<typeof runSync>
+
+describe('makeSyncGamesHandler — engine warm-up', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedRunSync.mockResolvedValue({ gamesProcessed: 1, cardsCreated: 0, errors: [] })
+  })
+
+  it('forwards an injected engineFactory into runSync so the worker can share one warm engine across jobs', async () => {
+    const warmEngine = { postMessage: jest.fn(), onmessage: null }
+    const engineFactory = jest.fn(() => warmEngine)
+
+    const handler = makeSyncGamesHandler({ engineFactory })
+
+    const step = {
+      run: jest.fn(async (_id: string, fn: () => unknown) => await fn()),
+    }
+
+    await handler({
+      event: {
+        data: {
+          syncLogId: 'log-1',
+          userId: 'user-1',
+          username: 'alice',
+          mode: 'incremental',
+        },
+      },
+      step,
+    } as unknown as Parameters<typeof handler>[0])
+
+    const [, opts] = mockedRunSync.mock.calls[0]
+    expect(opts.engineFactory).toBe(engineFactory)
+  })
+
+  it('default handler (no deps) passes engineFactory=undefined so runSync falls back to per-game default engine creation', async () => {
+    const handler = makeSyncGamesHandler({})
+
+    const step = {
+      run: jest.fn(async (_id: string, fn: () => unknown) => await fn()),
+    }
+
+    await handler({
+      event: {
+        data: {
+          syncLogId: 'log-1',
+          userId: 'user-1',
+          username: 'alice',
+          mode: 'incremental',
+        },
+      },
+      step,
+    } as unknown as Parameters<typeof handler>[0])
+
+    const [, opts] = mockedRunSync.mock.calls[0]
+    expect(opts.engineFactory).toBeUndefined()
+  })
+})

--- a/__tests__/worker/engine-warmup.test.ts
+++ b/__tests__/worker/engine-warmup.test.ts
@@ -20,14 +20,16 @@ describe('worker engine warm-up', () => {
     const engineFactory = jest.fn(async () => engine)
 
     const capturedFactories: Array<() => unknown> = []
-    const makeHandlerSpy = jest.fn((deps: { engineFactory?: () => unknown }) => {
+    const makeHandlerSpy = jest.fn((deps: { engineFactory?: () => unknown } = {}) => {
       if (deps.engineFactory) capturedFactories.push(deps.engineFactory)
-      return async () => ({})
+      return (async () => ({})) as unknown as ReturnType<
+        typeof import('@/lib/inngest/functions').makeSyncGamesHandler
+      >
     })
 
     await createWorkerFunctions({
       engineFactory,
-      makeHandler: makeHandlerSpy,
+      makeHandler: makeHandlerSpy as unknown as typeof import('@/lib/inngest/functions').makeSyncGamesHandler,
     })
 
     expect(capturedFactories.length).toBeGreaterThan(0)

--- a/__tests__/worker/engine-warmup.test.ts
+++ b/__tests__/worker/engine-warmup.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+import { createWorkerFunctions } from '../../worker/src/functions'
+
+describe('worker engine warm-up', () => {
+  it('createWorkerFunctions resolves the engineFactory exactly once regardless of how many functions are registered', async () => {
+    const engine = { postMessage: jest.fn(), onmessage: null }
+    const engineFactory = jest.fn(async () => engine)
+
+    const functions = await createWorkerFunctions({ engineFactory })
+
+    expect(functions.length).toBeGreaterThan(0)
+    expect(engineFactory).toHaveBeenCalledTimes(1)
+  })
+
+  it('every registered function reuses the same warm engine instance', async () => {
+    const engine = { postMessage: jest.fn(), onmessage: null }
+    const engineFactory = jest.fn(async () => engine)
+
+    const capturedFactories: Array<() => unknown> = []
+    const makeHandlerSpy = jest.fn((deps: { engineFactory?: () => unknown }) => {
+      if (deps.engineFactory) capturedFactories.push(deps.engineFactory)
+      return async () => ({})
+    })
+
+    await createWorkerFunctions({
+      engineFactory,
+      makeHandler: makeHandlerSpy,
+    })
+
+    expect(capturedFactories.length).toBeGreaterThan(0)
+    for (const factory of capturedFactories) {
+      expect(await factory()).toBe(engine)
+    }
+  })
+})

--- a/__tests__/worker/functions.test.ts
+++ b/__tests__/worker/functions.test.ts
@@ -1,0 +1,8 @@
+import { workerFunctions } from '../../worker/src/functions'
+import { syncGamesFunction } from '../../lib/inngest/functions'
+
+describe('worker-registered Inngest functions', () => {
+  it('includes the syncGamesFunction so Inngest events route to the worker', () => {
+    expect(workerFunctions).toContain(syncGamesFunction)
+  })
+})

--- a/__tests__/worker/functions.test.ts
+++ b/__tests__/worker/functions.test.ts
@@ -1,8 +1,12 @@
-import { workerFunctions } from '../../worker/src/functions'
-import { syncGamesFunction } from '../../lib/inngest/functions'
+import { createWorkerFunctions } from '../../worker/src/functions'
 
-describe('worker-registered Inngest functions', () => {
-  it('includes the syncGamesFunction so Inngest events route to the worker', () => {
-    expect(workerFunctions).toContain(syncGamesFunction)
+describe('createWorkerFunctions', () => {
+  it('returns a non-empty list of Inngest functions', async () => {
+    const engine = { postMessage: jest.fn(), onmessage: null }
+    const functions = await createWorkerFunctions({
+      engineFactory: async () => engine,
+    })
+
+    expect(functions.length).toBeGreaterThan(0)
   })
 })

--- a/__tests__/worker/server.test.ts
+++ b/__tests__/worker/server.test.ts
@@ -1,0 +1,96 @@
+import { createRequestHandler } from '../../worker/src/server'
+
+describe('worker HTTP server', () => {
+  describe('GET /health', () => {
+    it('returns 200 with { status: "ok" } JSON payload', async () => {
+      const handler = createRequestHandler({ functions: [] })
+
+      const { status, headers, body } = await invoke(handler, 'GET', '/health')
+
+      expect(status).toBe(200)
+      expect(headers['content-type']).toMatch(/application\/json/)
+      expect(JSON.parse(body)).toMatchObject({ status: 'ok' })
+    })
+
+    it('reports engineWarm=false before engine is registered', async () => {
+      const handler = createRequestHandler({ functions: [] })
+
+      const { body } = await invoke(handler, 'GET', '/health')
+
+      expect(JSON.parse(body)).toMatchObject({ engineWarm: false })
+    })
+
+    it('reports engineWarm=true once a warm engine is registered', async () => {
+      const handler = createRequestHandler({
+        functions: [],
+        getEngineWarm: () => true,
+      })
+
+      const { body } = await invoke(handler, 'GET', '/health')
+
+      expect(JSON.parse(body)).toMatchObject({ engineWarm: true })
+    })
+  })
+
+  describe('unknown route', () => {
+    it('returns 404 for unrecognised paths', async () => {
+      const handler = createRequestHandler({ functions: [] })
+
+      const { status } = await invoke(handler, 'GET', '/does-not-exist')
+
+      expect(status).toBe(404)
+    })
+  })
+
+  describe('/api/inngest', () => {
+    it('delegates to the Inngest serve handler', async () => {
+      const calls: Array<{ url: string | undefined; method: string | undefined }> = []
+      const fakeServe = (req: { url?: string; method?: string }, res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (b?: string) => void }) => {
+        calls.push({ url: req.url, method: req.method })
+        res.statusCode = 200
+        res.setHeader('content-type', 'application/json')
+        res.end('{"ok":true}')
+      }
+
+      const handler = createRequestHandler({ functions: [], serveHandler: fakeServe })
+      const { status, body } = await invoke(handler, 'POST', '/api/inngest')
+
+      expect(status).toBe(200)
+      expect(body).toBe('{"ok":true}')
+      expect(calls).toHaveLength(1)
+      expect(calls[0].method).toBe('POST')
+    })
+  })
+})
+
+// Minimal mock of http.IncomingMessage / ServerResponse for handler tests.
+function invoke(
+  handler: (req: FakeReq, res: FakeRes) => void | Promise<void>,
+  method: string,
+  url: string,
+): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+  const req: FakeReq = { method, url, headers: {} }
+  return new Promise((resolve) => {
+    const res: FakeRes = {
+      statusCode: 200,
+      _headers: {},
+      setHeader(k, v) {
+        this._headers[k.toLowerCase()] = v
+      },
+      end(body?: string) {
+        resolve({ status: this.statusCode, headers: this._headers, body: body ?? '' })
+      },
+    }
+    Promise.resolve(handler(req, res)).catch((err) => {
+      resolve({ status: 500, headers: {}, body: String(err) })
+    })
+  })
+}
+
+type FakeReq = { method?: string; url?: string; headers: Record<string, string> }
+type FakeRes = {
+  statusCode: number
+  _headers: Record<string, string>
+  setHeader: (k: string, v: string) => void
+  end: (body?: string) => void
+}

--- a/__tests__/worker/server.test.ts
+++ b/__tests__/worker/server.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage, ServerResponse, RequestListener } from 'http'
 import { createRequestHandler } from '../../worker/src/server'
 
 describe('worker HTTP server', () => {
@@ -45,12 +46,12 @@ describe('worker HTTP server', () => {
   describe('/api/inngest', () => {
     it('delegates to the Inngest serve handler', async () => {
       const calls: Array<{ url: string | undefined; method: string | undefined }> = []
-      const fakeServe = (req: { url?: string; method?: string }, res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (b?: string) => void }) => {
+      const fakeServe = ((req: { url?: string; method?: string }, res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (b?: string) => void }) => {
         calls.push({ url: req.url, method: req.method })
         res.statusCode = 200
         res.setHeader('content-type', 'application/json')
         res.end('{"ok":true}')
-      }
+      }) as unknown as Parameters<typeof createRequestHandler>[0]['serveHandler']
 
       const handler = createRequestHandler({ functions: [], serveHandler: fakeServe })
       const { status, body } = await invoke(handler, 'POST', '/api/inngest')
@@ -65,32 +66,39 @@ describe('worker HTTP server', () => {
 
 // Minimal mock of http.IncomingMessage / ServerResponse for handler tests.
 function invoke(
-  handler: (req: FakeReq, res: FakeRes) => void | Promise<void>,
+  handler: RequestListener,
   method: string,
   url: string,
 ): Promise<{ status: number; headers: Record<string, string>; body: string }> {
-  const req: FakeReq = { method, url, headers: {} }
+  const req = { method, url, headers: {} } as unknown as IncomingMessage
   return new Promise((resolve) => {
-    const res: FakeRes = {
+    const captured: { statusCode: number; _headers: Record<string, string> } = {
       statusCode: 200,
       _headers: {},
-      setHeader(k, v) {
-        this._headers[k.toLowerCase()] = v
+    }
+    const res = {
+      get statusCode() {
+        return captured.statusCode
+      },
+      set statusCode(v: number) {
+        captured.statusCode = v
+      },
+      setHeader(k: string, v: string) {
+        captured._headers[k.toLowerCase()] = v
       },
       end(body?: string) {
-        resolve({ status: this.statusCode, headers: this._headers, body: body ?? '' })
+        resolve({ status: captured.statusCode, headers: captured._headers, body: body ?? '' })
       },
-    }
-    Promise.resolve(handler(req, res)).catch((err) => {
+    } as unknown as ServerResponse
+    try {
+      const result = handler(req, res) as unknown as Promise<unknown> | void
+      if (result && typeof (result as Promise<unknown>).catch === 'function') {
+        ;(result as Promise<unknown>).catch((err) => {
+          resolve({ status: 500, headers: {}, body: String(err) })
+        })
+      }
+    } catch (err) {
       resolve({ status: 500, headers: {}, body: String(err) })
-    })
+    }
   })
-}
-
-type FakeReq = { method?: string; url?: string; headers: Record<string, string> }
-type FakeRes = {
-  statusCode: number
-  _headers: Record<string, string>
-  setHeader: (k: string, v: string) => void
-  end: (body?: string) => void
 }

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -1,14 +1,15 @@
 import { serve } from 'inngest/next'
+import type { InngestFunction } from 'inngest'
 import { inngest } from '@/lib/inngest/client'
-import { syncGamesFunction } from '@/lib/inngest/functions'
 
-// Each Inngest step runs as its own invocation of this handler. A single
-// game's Stockfish analysis needs well more than Vercel's default budget —
-// 300s (5 min, Vercel Pro ceiling) gives ample headroom per step while the
-// step.run memoization keeps the whole sync resumable.
-export const maxDuration = 300
+// Slice 6 (#74): the sync pipeline runs on the Fly.io worker now. Vercel no
+// longer serves `sync-games`, because serverless cold-starts can't load the
+// 40MB Stockfish NNUE weights without freezing the event loop (issue #67).
+// The route is kept as an empty serve() so any future non-sync Inngest
+// functions can slot in without re-wiring the Next.js app.
+export const vercelInngestFunctions: InngestFunction.Any[] = []
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
-  functions: [syncGamesFunction],
+  functions: vercelInngestFunctions,
 })

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -1,13 +1,6 @@
 import { serve } from 'inngest/next'
-import type { InngestFunction } from 'inngest'
 import { inngest } from '@/lib/inngest/client'
-
-// Slice 6 (#74): the sync pipeline runs on the Fly.io worker now. Vercel no
-// longer serves `sync-games`, because serverless cold-starts can't load the
-// 40MB Stockfish NNUE weights without freezing the event loop (issue #67).
-// The route is kept as an empty serve() so any future non-sync Inngest
-// functions can slot in without re-wiring the Next.js app.
-export const vercelInngestFunctions: InngestFunction.Any[] = []
+import { vercelInngestFunctions } from '@/lib/inngest/vercel-functions'
 
 export const { GET, POST, PUT } = serve({
   client: inngest,

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
-  testPathIgnorePatterns: ["/node_modules/", "/e2e/", "/.next/"],
+  testPathIgnorePatterns: ["/node_modules/", "/e2e/", "/.next/", "/.claude/"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },

--- a/lib/chess-com/archive-cache.ts
+++ b/lib/chess-com/archive-cache.ts
@@ -1,0 +1,55 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { ArchiveCache, ConditionalCacheHints } from './client'
+
+/**
+ * Supabase-backed archive cache. One row per (user_id, year, month) stores
+ * the ETag / Last-Modified header we last saw so the next sync can send
+ * `If-None-Match` and get a cheap 304 for immutable past months.
+ *
+ * Writes are best-effort: if persisting the cache fails, the sync should
+ * still complete. Log but swallow errors.
+ */
+export function makeSupabaseArchiveCache(
+  db: SupabaseClient,
+  userId: string,
+): ArchiveCache {
+  return {
+    async get(year: number, month: number): Promise<ConditionalCacheHints | null> {
+      const { data, error } = await db
+        .from('chess_com_archives')
+        .select('etag,last_modified')
+        .eq('user_id', userId)
+        .eq('year', year)
+        .eq('month', month)
+        .maybeSingle()
+      if (error || !data) return null
+      return {
+        etag: data.etag ?? null,
+        lastModified: data.last_modified ?? null,
+      }
+    },
+
+    async set(
+      year: number,
+      month: number,
+      value: { etag: string | null; lastModified: string | null },
+    ): Promise<void> {
+      const { error } = await db
+        .from('chess_com_archives')
+        .upsert(
+          {
+            user_id: userId,
+            year,
+            month,
+            etag: value.etag,
+            last_modified: value.lastModified,
+            fetched_at: new Date().toISOString(),
+          },
+          { onConflict: 'user_id,year,month' },
+        )
+      if (error) {
+        console.warn('[archive-cache] failed to persist row', { year, month, error })
+      }
+    },
+  }
+}

--- a/lib/chess-com/client.ts
+++ b/lib/chess-com/client.ts
@@ -4,17 +4,66 @@ const CHESS_COM_BASE = 'https://api.chess.com/pub/player'
 // Identify the app and include a contact address per their guidelines.
 const USER_AGENT = 'ChessImprover/1.0 (https://chess-game-reviewer.vercel.app)'
 
-function chessComHeaders(): HeadersInit {
-  return { 'User-Agent': USER_AGENT }
+// Exponential backoff steps for 429 retries (in ms). Chess.com's rate limit
+// is per-IP, so a single transient 429 shouldn't kill a whole sync — sleep
+// and try again. 1+2+4+8 = 15s of wait across up to 4 retries before we give
+// up and surface the error to the caller.
+const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000]
+
+function chessComHeaders(extra: Record<string, string> = {}): HeadersInit {
+  return { 'User-Agent': USER_AGENT, ...extra }
 }
 
 export class ChessComApiError extends Error {
   constructor(
     message: string,
-    public readonly statusCode: number
+    public readonly statusCode: number,
   ) {
     super(message)
     this.name = 'ChessComApiError'
+  }
+}
+
+/**
+ * Opaque cache hints the caller has on file from a previous fetch. If both
+ * are present, `If-None-Match` takes precedence (ETag is the stronger
+ * validator on chess.com).
+ */
+export interface ConditionalCacheHints {
+  etag?: string | null
+  lastModified?: string | null
+}
+
+export interface ConditionalArchiveResponse {
+  /** 200 = fresh data, 304 = unchanged. */
+  status: 200 | 304
+  pgns: string[]
+  etag: string | null
+  lastModified: string | null
+}
+
+export interface ArchiveCache {
+  get(year: number, month: number): Promise<ConditionalCacheHints | null>
+  set(
+    year: number,
+    month: number,
+    data: { etag: string | null; lastModified: string | null },
+  ): Promise<void>
+}
+
+/**
+ * Fetch wrapper that retries on HTTP 429 with exponential backoff. Everything
+ * else (network errors, 4xx, 5xx) bubbles up immediately so the caller can
+ * decide whether to retry at a higher level.
+ */
+async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+  let attempt = 0
+  while (true) {
+    const res = await fetch(url, init)
+    if (res.status !== 429) return res
+    if (attempt >= RETRY_DELAYS_MS.length) return res
+    await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]))
+    attempt++
   }
 }
 
@@ -23,12 +72,12 @@ export async function fetchArchiveList(username: string): Promise<string[]> {
   // 'catalyst030119' returns 200. Normalize at the boundary.
   // The archives index lives at /games/archives, NOT /archives.
   const url = `${CHESS_COM_BASE}/${username.toLowerCase()}/games/archives`
-  const response = await fetch(url, { headers: chessComHeaders() })
+  const response = await fetchWithRetry(url, { headers: chessComHeaders() })
 
   if (!response.ok) {
     throw new ChessComApiError(
       `Chess.com API error: ${response.status}`,
-      response.status
+      response.status,
     )
   }
 
@@ -36,45 +85,17 @@ export async function fetchArchiveList(username: string): Promise<string[]> {
   return data.archives ?? []
 }
 
-export async function fetchGames(
-  username: string,
-  mode: 'historical' | 'incremental',
-  options?: { delayMs?: number }
-): Promise<string[]> {
-  const archives = await fetchArchiveList(username)
-
-  if (archives.length === 0) return []
-
-  const targets = mode === 'incremental' ? [archives[archives.length - 1]] : archives
-
-  const allPgns: string[] = []
-  for (const archiveUrl of targets) {
-    const delayMs = options?.delayMs ?? 0
-    if (delayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs))
-    }
-
-    const response = await fetch(archiveUrl, { headers: chessComHeaders() })
-    if (!response.ok) {
-      throw new ChessComApiError(
-        `Chess.com API error: ${response.status}`,
-        response.status
-      )
-    }
-    const data = await response.json()
-    const games: Array<{ pgn: string }> = data.games ?? []
-    allPgns.push(...games.map((g) => g.pgn))
-  }
-
-  return allPgns
+export interface FetchMonthlyArchiveOptions {
+  delayMs?: number
+  cache?: ConditionalCacheHints
 }
 
 export async function fetchMonthlyArchive(
   username: string,
   year: number,
   month: number,
-  options?: { delayMs?: number }
-): Promise<string[]> {
+  options?: FetchMonthlyArchiveOptions,
+): Promise<ConditionalArchiveResponse> {
   const delayMs = options?.delayMs ?? 0
 
   if (delayMs > 0) {
@@ -84,16 +105,90 @@ export async function fetchMonthlyArchive(
   const mm = String(month).padStart(2, '0')
   const url = `https://api.chess.com/pub/player/${username.toLowerCase()}/games/${year}/${mm}`
 
-  const response = await fetch(url, { headers: chessComHeaders() })
+  const conditional: Record<string, string> = {}
+  if (options?.cache?.etag) conditional['If-None-Match'] = options.cache.etag
+  if (options?.cache?.lastModified) conditional['If-Modified-Since'] = options.cache.lastModified
+
+  const response = await fetchWithRetry(url, { headers: chessComHeaders(conditional) })
+
+  if (response.status === 304) {
+    return { status: 304, pgns: [], etag: null, lastModified: null }
+  }
 
   if (!response.ok) {
     throw new ChessComApiError(
       `Chess.com API error: ${response.status}`,
-      response.status
+      response.status,
     )
   }
 
   const data = await response.json()
   const games: Array<{ pgn: string }> = data.games ?? []
-  return games.map((g) => g.pgn)
+  return {
+    status: 200,
+    pgns: games.map((g) => g.pgn),
+    etag: response.headers.get('etag'),
+    lastModified: response.headers.get('last-modified'),
+  }
+}
+
+function parseArchiveUrl(archiveUrl: string): { year: number; month: number } | null {
+  // Chess.com archive URLs look like
+  //   https://api.chess.com/pub/player/<user>/games/<yyyy>/<mm>
+  const match = archiveUrl.match(/\/games\/(\d{4})\/(\d{2})$/)
+  if (!match) return null
+  return { year: parseInt(match[1], 10), month: parseInt(match[2], 10) }
+}
+
+export async function fetchGames(
+  username: string,
+  mode: 'historical' | 'incremental',
+  options?: { delayMs?: number; archiveCache?: ArchiveCache },
+): Promise<string[]> {
+  const archives = await fetchArchiveList(username)
+  if (archives.length === 0) return []
+
+  const targets = mode === 'incremental' ? [archives[archives.length - 1]] : archives
+  const delayMs = options?.delayMs ?? 0
+  const cache = options?.archiveCache
+
+  const allPgns: string[] = []
+  for (const archiveUrl of targets) {
+    const ym = parseArchiveUrl(archiveUrl)
+    // If the URL doesn't match our expected shape, fall back to a bare fetch
+    // — never let cache plumbing block a real sync.
+    if (!ym) {
+      const response = await fetchWithRetry(archiveUrl, { headers: chessComHeaders() })
+      if (!response.ok) {
+        throw new ChessComApiError(
+          `Chess.com API error: ${response.status}`,
+          response.status,
+        )
+      }
+      if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs))
+      const data = await response.json()
+      const games: Array<{ pgn: string }> = data.games ?? []
+      allPgns.push(...games.map((g) => g.pgn))
+      continue
+    }
+
+    const cacheHints = cache ? (await cache.get(ym.year, ym.month)) ?? undefined : undefined
+    const result = await fetchMonthlyArchive(username, ym.year, ym.month, {
+      delayMs,
+      cache: cacheHints,
+    })
+
+    if (result.status === 200) {
+      allPgns.push(...result.pgns)
+      if (cache) {
+        await cache.set(ym.year, ym.month, {
+          etag: result.etag,
+          lastModified: result.lastModified,
+        })
+      }
+    }
+    // 304 → archive unchanged since last sync, caller already has the games.
+  }
+
+  return allPgns
 }

--- a/lib/inngest/functions.ts
+++ b/lib/inngest/functions.ts
@@ -3,10 +3,17 @@ import { inngest } from './client'
 import { runSync, type SyncProgress, type StepRunner } from '@/lib/sync-orchestrator'
 import { createServiceClient } from '@/lib/supabase-service'
 import { makeSupabaseStepLogger } from '@/lib/sync-step-logger'
+import type { UciEngine } from '@/lib/stockfish-analyzer'
 import { markSyncFailed } from './terminal-state'
 
 export interface SyncGamesDeps {
-  db?: SupabaseClient
+  /**
+   * Factory that returns the Stockfish engine to use for analysis. When the
+   * sync runs on the persistent worker this points at a single warm engine
+   * that was initialised at boot; on Vercel it stays undefined and
+   * `analyzeGame` falls back to the default per-game factory.
+   */
+  engineFactory?: () => UciEngine | Promise<UciEngine>
 }
 
 interface SyncGamesHandlerArgs {
@@ -22,85 +29,97 @@ interface SyncGamesHandlerArgs {
 }
 
 /**
- * The handler body for the Inngest sync-games function. Extracted as a named
- * export so unit tests can drive it directly with a stub `step` without
- * needing the Inngest runtime.
+ * Builds the handler body for the Inngest sync-games function. Injecting
+ * `engineFactory` at build time is what lets the persistent worker share a
+ * single warm Stockfish engine across every job instead of paying the 40MB
+ * NNUE cold-load on every invocation (issue #67 / plan F #74).
  */
-export async function syncGamesHandler({ event, step }: SyncGamesHandlerArgs) {
-  const { syncLogId, userId, username, mode } = event.data
+export function makeSyncGamesHandler(deps: SyncGamesDeps = {}) {
+  return async function syncGamesHandler({ event, step }: SyncGamesHandlerArgs) {
+    const { syncLogId, userId, username, mode } = event.data
 
-  const db: SupabaseClient = createServiceClient()
+    const db: SupabaseClient = createServiceClient()
 
-  await step.run('mark-fetching', async () => {
-    await db
-      .from('sync_log')
-      .update({ stage: 'fetching' })
-      .eq('id', syncLogId)
-  })
-
-  try {
-    const result = await runSync(mode, {
-      username,
-      userId,
-      db,
-      step,
-      stepLogger: makeSupabaseStepLogger(db, syncLogId),
-      onProgress: async (p: SyncProgress) => {
-        await db
-          .from('sync_log')
-          .update({
-            stage: p.stage,
-            games_total: p.gamesTotal,
-            games_processed: p.gamesProcessed,
-            cards_created: p.cardsCreated,
-          })
-          .eq('id', syncLogId)
-      },
-    })
-
-    await step.run('mark-complete', async () => {
+    await step.run('mark-fetching', async () => {
       await db
         .from('sync_log')
-        .update({
-          stage: 'complete',
-          completed_at: new Date().toISOString(),
-          games_processed: result.gamesProcessed,
-          cards_created: result.cardsCreated,
-          error: result.errors.length > 0 ? result.errors.join('; ') : null,
-        })
+        .update({ stage: 'fetching' })
         .eq('id', syncLogId)
     })
 
-    return result
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    await markSyncFailed(db, syncLogId, message)
-    throw err
+    try {
+      const result = await runSync(mode, {
+        username,
+        userId,
+        db,
+        step,
+        engineFactory: deps.engineFactory,
+        stepLogger: makeSupabaseStepLogger(db, syncLogId),
+        onProgress: async (p: SyncProgress) => {
+          await db
+            .from('sync_log')
+            .update({
+              stage: p.stage,
+              games_total: p.gamesTotal,
+              games_processed: p.gamesProcessed,
+              cards_created: p.cardsCreated,
+            })
+            .eq('id', syncLogId)
+        },
+      })
+
+      await step.run('mark-complete', async () => {
+        await db
+          .from('sync_log')
+          .update({
+            stage: 'complete',
+            completed_at: new Date().toISOString(),
+            games_processed: result.gamesProcessed,
+            cards_created: result.cardsCreated,
+            error: result.errors.length > 0 ? result.errors.join('; ') : null,
+          })
+          .eq('id', syncLogId)
+      })
+
+      return result
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      await markSyncFailed(db, syncLogId, message)
+      throw err
+    }
   }
 }
 
+/** Default handler with no injected deps — used by Vercel /api/inngest. */
+export const syncGamesHandler = makeSyncGamesHandler()
+
 /**
- * Inngest function that runs the full sync pipeline in the background and
- * writes live progress to the target `sync_log` row as it goes.
+ * Builds the Inngest sync-games function. Worker code calls this with a
+ * warmed-engine factory; Vercel uses the default export below, which has
+ * no injected deps.
  *
  * Event payload: { syncLogId, userId, username, mode }
  */
-export const syncGamesFunction = inngest.createFunction(
-  {
-    id: 'sync-games',
-    name: 'Sync Chess.com games',
-    triggers: [{ event: 'sync/run' }],
-    // Runs after all retries are exhausted. Without this, a function that
-    // times out or crashes mid-run leaves sync_log.stage stuck on whatever
-    // the last onProgress write was (usually 'analyzing'), and the client
-    // polls forever because it's waiting for a terminal stage.
-    onFailure: async ({ event, error }) => {
-      const { syncLogId } = (event.data.event?.data ?? {}) as { syncLogId?: string }
-      if (!syncLogId) return
-      const db = createServiceClient()
-      const message = error instanceof Error ? error.message : String(error)
-      await markSyncFailed(db, syncLogId, message)
+export function createSyncGamesFunction(deps: SyncGamesDeps = {}) {
+  return inngest.createFunction(
+    {
+      id: 'sync-games',
+      name: 'Sync Chess.com games',
+      triggers: [{ event: 'sync/run' }],
+      // Runs after all retries are exhausted. Without this, a function that
+      // times out or crashes mid-run leaves sync_log.stage stuck on whatever
+      // the last onProgress write was (usually 'analyzing'), and the client
+      // polls forever because it's waiting for a terminal stage.
+      onFailure: async ({ event, error }) => {
+        const { syncLogId } = (event.data.event?.data ?? {}) as { syncLogId?: string }
+        if (!syncLogId) return
+        const db = createServiceClient()
+        const message = error instanceof Error ? error.message : String(error)
+        await markSyncFailed(db, syncLogId, message)
+      },
     },
-  },
-  syncGamesHandler as unknown as Parameters<typeof inngest.createFunction>[1],
-)
+    makeSyncGamesHandler(deps) as unknown as Parameters<typeof inngest.createFunction>[1],
+  )
+}
+
+export const syncGamesFunction = createSyncGamesFunction()

--- a/lib/inngest/functions.ts
+++ b/lib/inngest/functions.ts
@@ -4,6 +4,8 @@ import { runSync, type SyncProgress, type StepRunner } from '@/lib/sync-orchestr
 import { createServiceClient } from '@/lib/supabase-service'
 import { makeSupabaseStepLogger } from '@/lib/sync-step-logger'
 import type { UciEngine } from '@/lib/stockfish-analyzer'
+import { fetchGames } from '@/lib/chess-com/client'
+import { makeSupabaseArchiveCache } from '@/lib/chess-com/archive-cache'
 import { markSyncFailed } from './terminal-state'
 
 export interface SyncGamesDeps {
@@ -47,6 +49,8 @@ export function makeSyncGamesHandler(deps: SyncGamesDeps = {}) {
         .eq('id', syncLogId)
     })
 
+    const archiveCache = makeSupabaseArchiveCache(db, userId)
+
     try {
       const result = await runSync(mode, {
         username,
@@ -54,6 +58,7 @@ export function makeSyncGamesHandler(deps: SyncGamesDeps = {}) {
         db,
         step,
         engineFactory: deps.engineFactory,
+        gamesFetcher: (u, m) => fetchGames(u, m, { archiveCache }),
         stepLogger: makeSupabaseStepLogger(db, syncLogId),
         onProgress: async (p: SyncProgress) => {
           await db
@@ -106,6 +111,11 @@ export function createSyncGamesFunction(deps: SyncGamesDeps = {}) {
       id: 'sync-games',
       name: 'Sync Chess.com games',
       triggers: [{ event: 'sync/run' }],
+      // Chess.com's public API is per-IP rate-limited. Cap outbound requests
+      // across every worker so one busy sync can't starve another user's of
+      // rate-limit budget. 3 is comfortably under chess.com's published
+      // limit and leaves headroom for retries.
+      concurrency: [{ limit: 3, key: '"chess-com"' }],
       // Runs after all retries are exhausted. Without this, a function that
       // times out or crashes mid-run leaves sync_log.stage stuck on whatever
       // the last onProgress write was (usually 'analyzing'), and the client

--- a/lib/inngest/vercel-functions.ts
+++ b/lib/inngest/vercel-functions.ts
@@ -1,0 +1,12 @@
+import type { InngestFunction } from 'inngest'
+
+// Slice 6 (#74): the sync pipeline runs on the Fly.io worker now. Vercel's
+// /api/inngest route no longer registers sync-games, because serverless
+// cold-starts can't load the 40MB Stockfish NNUE weights without freezing
+// the event loop (issue #67). The array is kept (empty) so any future
+// non-sync Inngest functions can slot in without re-wiring the Next.js app.
+//
+// Lives in `lib/` rather than inside `app/api/inngest/route.ts` because
+// Next.js 15's route-file type check only allows named exports like
+// `GET` / `POST` / `dynamic` — anything else fails the build.
+export const vercelInngestFunctions: InngestFunction.Any[] = []

--- a/lib/stockfish-analyzer.ts
+++ b/lib/stockfish-analyzer.ts
@@ -163,7 +163,7 @@ export async function analyzeGame(
   return results
 }
 
-async function createDefaultEngine(): Promise<UciEngine> {
+export async function createDefaultEngine(): Promise<UciEngine> {
   // The Stockfish WASM build is an Emscripten module factory. The correct
   // initialization is `Stockfish()` (returns a second factory) → `factory()`
   // (returns a Promise that resolves to the actual engine with .postMessage).

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "jest": "^29",
         "jest-environment-jsdom": "^29",
         "ts-jest": "^29",
+        "tsc-alias": "^1.8.16",
         "typescript": "^5"
       }
     },
@@ -1654,6 +1655,44 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -3874,6 +3913,16 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4024,6 +4073,19 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -4207,6 +4269,31 @@
       "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -4296,6 +4383,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-map": {
@@ -4533,6 +4630,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dnd-core": {
@@ -4818,12 +4928,39 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -5100,6 +5237,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5120,6 +5270,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/google-logging-utils": {
@@ -5330,6 +5514,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-in-the-middle": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
@@ -5500,6 +5694,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -5513,6 +5720,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -5532,6 +5749,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -6852,6 +7082,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6949,6 +7189,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mylas": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
+      "integrity": "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7289,6 +7543,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -7406,6 +7670,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/postcss": {
@@ -7590,6 +7867,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -7682,6 +7990,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -7778,6 +8099,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -7786,6 +8117,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safer-buffer": {
@@ -8304,6 +8670,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "^29",
     "jest-environment-jsdom": "^29",
     "ts-jest": "^29",
+    "tsc-alias": "^1.8.16",
     "typescript": "^5"
   }
 }

--- a/supabase/migrations/012_chess_com_archives.sql
+++ b/supabase/migrations/012_chess_com_archives.sql
@@ -1,0 +1,35 @@
+-- Migration: 012_chess_com_archives
+-- Per-(user, year, month) archive cache so repeat syncs can send
+-- `If-None-Match` / `If-Modified-Since` and get a 304 on immutable past
+-- months. Dramatically reduces chess.com API pressure for returning users
+-- (historical sync with a populated cache: 36 requests → ~2 instead of 36
+-- full archive reads).
+
+CREATE TABLE IF NOT EXISTS "chess_com_archives" (
+  "id"            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"       UUID NOT NULL REFERENCES "users" ("id") ON DELETE CASCADE,
+  "year"          INTEGER NOT NULL,
+  "month"         INTEGER NOT NULL CHECK ("month" BETWEEN 1 AND 12),
+  "etag"          TEXT,
+  "last_modified" TEXT,
+  "fetched_at"    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE ("user_id", "year", "month")
+);
+
+CREATE INDEX IF NOT EXISTS "chess_com_archives_user_idx"
+  ON "chess_com_archives" ("user_id", "year", "month");
+
+-- RLS: a user can only see/write their own archive cache rows.
+ALTER TABLE "chess_com_archives" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "chess_com_archives_select_own" ON "chess_com_archives"
+  FOR SELECT USING (auth.uid() = "user_id");
+
+CREATE POLICY "chess_com_archives_insert_own" ON "chess_com_archives"
+  FOR INSERT WITH CHECK (auth.uid() = "user_id");
+
+CREATE POLICY "chess_com_archives_update_own" ON "chess_com_archives"
+  FOR UPDATE USING (auth.uid() = "user_id");
+
+CREATE POLICY "chess_com_archives_delete_own" ON "chess_com_archives"
+  FOR DELETE USING (auth.uid() = "user_id");

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,35 @@
+# Persistent worker image for the Chess Improver sync pipeline.
+# Loads Stockfish NNUE 16 weights once at boot and keeps the engine warm
+# across Inngest job invocations — fixes the cold-start 40MB-weights freeze
+# that made the Vercel/serverless pipeline hang (issue #67).
+
+FROM node:20-bookworm-slim AS base
+WORKDIR /app
+ENV NODE_ENV=production
+
+FROM base AS deps
+COPY package.json package-lock.json ./
+# The worker only needs a slice of the root dependency tree (inngest,
+# stockfish, supabase, chess.js), but installing from the root lock-file keeps
+# versions exactly in sync with the Next.js app that produces the events.
+RUN npm ci --omit=dev --ignore-scripts
+
+FROM base AS build
+COPY package.json package-lock.json tsconfig.json ./
+COPY --from=deps /app/node_modules ./node_modules
+# Dev deps required to compile TS. Separate layer so the final image stays thin.
+RUN npm ci --ignore-scripts
+COPY lib ./lib
+COPY types ./types
+COPY worker ./worker
+RUN npx tsc --project worker/tsconfig.json
+
+FROM base AS runtime
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/worker/dist ./worker/dist
+COPY --from=build /app/lib ./lib
+COPY --from=build /app/types ./types
+COPY package.json ./
+
+EXPOSE 3000
+CMD ["node", "worker/dist/worker/src/index.js"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -22,7 +22,12 @@ RUN npm ci --ignore-scripts
 COPY lib ./lib
 COPY types ./types
 COPY worker ./worker
-RUN npx tsc --project worker/tsconfig.json
+# tsc by itself leaves the `@/lib/...` path aliases in the emitted JS and
+# Node's CJS resolver then blows up at boot with MODULE_NOT_FOUND (tsconfig
+# `paths` is type-check-only). tsc-alias rewrites them into real relative
+# paths so the worker can actually start.
+RUN npx tsc --project worker/tsconfig.json \
+  && npx tsc-alias --project worker/tsconfig.json
 
 FROM base AS runtime
 COPY --from=deps /app/node_modules ./node_modules

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,56 @@
+# Chess Improver Sync Worker
+
+Persistent Node/Docker worker that runs the sync pipeline off a single
+always-on VM. Replaces the Vercel serverless path that was hanging on the
+40MB Stockfish NNUE-16 weights cold-load (issue #67 / plan F in #74).
+
+## Why a persistent worker
+
+Stockfish NNUE-16 loads a 40MB weights file via synchronous `fs.readFileSync`
+and a synchronous WASM compile. On Vercel's serverless cold-start model that
+blocks the event loop for 20–60s per invocation, long enough that no timeout
+could fire and Vercel eventually killed the container. A long-running
+container pays that cost once at boot and then serves every subsequent job
+warm.
+
+## Local usage
+
+```bash
+# Build
+cd worker && npx tsc
+# Run
+node dist/worker/src/index.js        # listens on :3000
+curl localhost:3000/health           # → {"status":"ok","engineWarm":false}
+```
+
+## Deploy to Fly.io (first-time setup)
+
+```bash
+brew install flyctl
+flyctl auth login
+flyctl apps create chess-improver-worker
+
+# Secrets — pull values from Vercel project env.
+flyctl secrets set \
+  SUPABASE_URL=... \
+  SUPABASE_SERVICE_ROLE_KEY=... \
+  INNGEST_EVENT_KEY=... \
+  INNGEST_SIGNING_KEY=... \
+  --app chess-improver-worker
+
+flyctl deploy --config worker/fly.toml --dockerfile worker/Dockerfile
+```
+
+## Deploying updates
+
+```bash
+flyctl deploy --config worker/fly.toml --dockerfile worker/Dockerfile
+```
+
+Once the worker is live, register its `/api/inngest` URL in the Inngest
+dashboard so events route to the worker instead of to Vercel.
+
+## Health
+
+`GET /health` → `{"status":"ok","engineWarm":<bool>}`.
+`engineWarm` flips to `true` once the Stockfish NNUE weights are loaded.

--- a/worker/SMOKE_TEST.md
+++ b/worker/SMOKE_TEST.md
@@ -1,0 +1,100 @@
+# Plan F worker — prod smoke test
+
+Run this checklist after the worker is deployed to Fly.io and its
+`/api/inngest` URL is registered in the Inngest dashboard. The test
+reproduces the scenario that was failing in issue #67: a real chess.com
+account with ~16 games must complete end-to-end, producing `analyze:ok`
+rows and `cards_created > 0`.
+
+Target account: **`catalyst030119`** (~16 games on chess.com, all short, a
+mix of wins/losses/draws so every classification branch of
+`move-classifier` gets hit).
+
+## 1. Confirm worker is live and warm
+
+```bash
+curl https://chess-improver-worker.fly.dev/health
+# Expect: {"status":"ok","engineWarm":true}
+```
+
+If `engineWarm` is `false` for more than ~90 seconds after boot, check
+Fly logs (`flyctl logs --app chess-improver-worker`) for a Stockfish
+init error. The `[worker] engine warm; N inngest functions registered`
+line must appear before moving on.
+
+## 2. Confirm Inngest registration
+
+Inngest dashboard → Apps → `chess-improver` → the URL listed for
+`sync-games` must be the worker's `/api/inngest`, not Vercel. If it
+still says Vercel, click "Sync app" and enter the worker URL.
+
+## 3. Trigger the sync from the UI
+
+1. Log in to https://chess-game-reviewer.vercel.app.
+2. Settings → set `chess_com_username = catalyst030119`.
+3. `/sync` → click "Start historical sync".
+
+## 4. Verify pipeline completion
+
+Open `/sync/audit` (or query `sync_step_log` directly). Expected rows
+for the latest `sync_log_id`:
+
+- [ ] `sync-start` → `ok`
+- [ ] `fetch-archives-start` → `ok`
+- [ ] `fetch-archives-end` → `ok`, details.count ≥ 1
+- [ ] For **each of ~16 games**:
+  - [ ] `parse-headers` → `ok`
+  - [ ] `parse-positions` → `ok`
+  - [ ] `ensure-game-row` → `ok`
+  - [ ] `analyze` → `ok`, details.positions > 0
+  - [ ] `generate-cards` → `ok`
+- [ ] `sync-end` → `ok`
+
+On the `sync_log` row:
+- [ ] `stage = 'complete'`
+- [ ] `games_processed > 0` (target: 16)
+- [ ] `cards_created > 0`
+- [ ] `error IS NULL`
+
+## 5. Verify ETag reuse on the second sync
+
+Kick off another historical sync for the same account:
+
+```sql
+-- Before:
+SELECT year, month, etag, fetched_at
+  FROM chess_com_archives
+  WHERE user_id = <uid> ORDER BY year DESC, month DESC;
+```
+
+Run the sync, then re-query. Every row's `etag` should be unchanged and
+`fetched_at` should advance — evidence that chess.com returned 304 and
+the worker reused the cache. Worker logs should NOT contain a
+`fetchMonthlyArchive 200 OK` line for months that already had a row.
+
+## 6. Verify 429 backoff (optional / manual)
+
+Artificially force a 429 by temporarily stubbing chess.com in a local
+worker run, or rely on the unit tests
+(`__tests__/lib/chess-com/retry.test.ts`) — the prod path isn't easy to
+exercise without rate-limit abuse.
+
+## 7. Regression gate
+
+Confirm none of these have changed behaviour:
+
+- [ ] #62: stale sync progress UI
+- [ ] #63: sync aborts mid-fetch
+- [ ] #64: per-game Inngest isolation
+- [ ] #65: sync hero + stat card driven off `syncRunStatusLabel`
+- [ ] #66: "last successful run" timestamp shown, not "last run"
+
+## Rollback
+
+If the smoke test fails:
+
+1. `flyctl deploy --image <previous-sha>` to roll the worker back, OR
+2. Re-register the Vercel `/api/inngest` URL in Inngest. This PR
+   removed the Vercel-side function list, so restore
+   `syncGamesFunction` in `app/api/inngest/route.ts` before redeploying
+   Vercel.

--- a/worker/fly.toml
+++ b/worker/fly.toml
@@ -1,0 +1,44 @@
+# Fly.io config for the Chess Improver sync worker.
+# Deploy from repo root: `flyctl deploy --config worker/fly.toml --dockerfile worker/Dockerfile`
+# The app name must match an existing Fly app (create once with `flyctl apps create chess-improver-worker`).
+
+app = "chess-improver-worker"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3000"
+
+# Single always-on VM. Stockfish NNUE weights (~40MB) load once at boot and
+# stay resident — auto_stop_machines would force a cold start on every idle
+# period, which is exactly the failure mode we're escaping from.
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [[services.http_checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "60s"
+    method = "get"
+    path = "/health"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 512

--- a/worker/src/functions.ts
+++ b/worker/src/functions.ts
@@ -1,0 +1,10 @@
+import type { InngestFunction } from 'inngest'
+import { syncGamesFunction } from '../../lib/inngest/functions'
+
+/**
+ * The full list of Inngest functions this worker handles. The Vercel
+ * `app/api/inngest/route.ts` is retired in slice 6 — after that, events flow
+ * exclusively to this worker, whose public URL is registered in the Inngest
+ * dashboard.
+ */
+export const workerFunctions: InngestFunction.Any[] = [syncGamesFunction]

--- a/worker/src/functions.ts
+++ b/worker/src/functions.ts
@@ -1,10 +1,40 @@
 import type { InngestFunction } from 'inngest'
-import { syncGamesFunction } from '../../lib/inngest/functions'
+import { createSyncGamesFunction, makeSyncGamesHandler } from '../../lib/inngest/functions'
+import { createDefaultEngine, type UciEngine } from '../../lib/stockfish-analyzer'
+
+export interface CreateWorkerFunctionsDeps {
+  /**
+   * Resolves the warm Stockfish engine. Called exactly once at boot; every
+   * registered Inngest function then reuses the same engine instance for
+   * every sync job it runs.
+   */
+  engineFactory?: () => UciEngine | Promise<UciEngine>
+  /**
+   * Test seam — lets a test assert that the handler built for each function
+   * receives a factory resolving to the same warm engine.
+   */
+  makeHandler?: typeof makeSyncGamesHandler
+}
 
 /**
- * The full list of Inngest functions this worker handles. The Vercel
- * `app/api/inngest/route.ts` is retired in slice 6 — after that, events flow
- * exclusively to this worker, whose public URL is registered in the Inngest
- * dashboard.
+ * Build the Inngest function list the worker will serve. Warms the Stockfish
+ * engine once and hands the same instance to every function via a shared
+ * factory — the key difference from Vercel, where each invocation pays the
+ * 40MB NNUE cold-load itself (issue #67 / plan F #74).
  */
-export const workerFunctions: InngestFunction.Any[] = [syncGamesFunction]
+export async function createWorkerFunctions(
+  deps: CreateWorkerFunctionsDeps = {},
+): Promise<InngestFunction.Any[]> {
+  const resolveEngine = deps.engineFactory ?? createDefaultEngine
+  const engine = await resolveEngine()
+  const sharedFactory = () => engine
+
+  // `makeHandler`'s only purpose is to let unit tests capture the factory
+  // passed into each function builder. Production code path just builds the
+  // sync-games function as normal.
+  if (deps.makeHandler) {
+    deps.makeHandler({ engineFactory: sharedFactory })
+  }
+
+  return [createSyncGamesFunction({ engineFactory: sharedFactory })]
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,13 +1,17 @@
 import http from 'http'
+import { serve } from 'inngest/node'
+import { inngest } from '../../lib/inngest/client'
 import { createRequestHandler } from './server'
+import { workerFunctions } from './functions'
 
 const PORT = Number(process.env.PORT ?? 3000)
 
-// Slice 1: minimal always-on process with a /health endpoint so the container
-// is deployable and Fly.io health-checks pass. Later slices register the
-// Inngest `syncGamesFunction` and a warm Stockfish engine.
 function main() {
-  const handler = createRequestHandler({ functions: [] })
+  const serveHandler = serve({ client: inngest, functions: workerFunctions })
+  const handler = createRequestHandler({
+    functions: workerFunctions,
+    serveHandler,
+  })
   const server = http.createServer(handler)
 
   server.listen(PORT, () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,21 +2,47 @@ import http from 'http'
 import { serve } from 'inngest/node'
 import { inngest } from '../../lib/inngest/client'
 import { createRequestHandler } from './server'
-import { workerFunctions } from './functions'
+import { createWorkerFunctions } from './functions'
 
 const PORT = Number(process.env.PORT ?? 3000)
 
-function main() {
-  const serveHandler = serve({ client: inngest, functions: workerFunctions })
+let engineWarm = false
+
+async function main() {
+  // Start the HTTP listener BEFORE awaiting the 40MB NNUE load so Fly.io's
+  // health-check can see the process is alive while it warms up. /health
+  // reports `engineWarm: false` until the factory promise resolves, then
+  // flips to `true` — that gives the platform a clean ready-signal to gate
+  // traffic on.
+  const preloadFunctionsPromise = createWorkerFunctions()
   const handler = createRequestHandler({
-    functions: workerFunctions,
-    serveHandler,
+    functions: [],
+    // Temporarily 503 Inngest requests until the engine is warm; Inngest's
+    // SDK retries on 5xx, so jobs delivered during boot aren't lost.
+    getEngineWarm: () => engineWarm,
   })
   const server = http.createServer(handler)
 
   server.listen(PORT, () => {
     console.log(`[worker] listening on :${PORT}`)
   })
+
+  const functions = await preloadFunctionsPromise
+  engineWarm = true
+  console.log(`[worker] engine warm; ${functions.length} inngest functions registered`)
+
+  const serveHandler = serve({ client: inngest, functions })
+  // Swap the handler in-place now that the engine is ready. The next HTTP
+  // request will pick up the new one.
+  server.removeAllListeners('request')
+  server.on(
+    'request',
+    createRequestHandler({
+      functions,
+      serveHandler,
+      getEngineWarm: () => engineWarm,
+    }),
+  )
 
   const shutdown = (signal: string) => {
     console.log(`[worker] ${signal} received, shutting down`)
@@ -27,5 +53,8 @@ function main() {
 }
 
 if (require.main === module) {
-  main()
+  main().catch((err) => {
+    console.error('[worker] failed to start', err)
+    process.exit(1)
+  })
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,27 @@
+import http from 'http'
+import { createRequestHandler } from './server'
+
+const PORT = Number(process.env.PORT ?? 3000)
+
+// Slice 1: minimal always-on process with a /health endpoint so the container
+// is deployable and Fly.io health-checks pass. Later slices register the
+// Inngest `syncGamesFunction` and a warm Stockfish engine.
+function main() {
+  const handler = createRequestHandler({ functions: [] })
+  const server = http.createServer(handler)
+
+  server.listen(PORT, () => {
+    console.log(`[worker] listening on :${PORT}`)
+  })
+
+  const shutdown = (signal: string) => {
+    console.log(`[worker] ${signal} received, shutting down`)
+    server.close(() => process.exit(0))
+  }
+  process.on('SIGTERM', () => shutdown('SIGTERM'))
+  process.on('SIGINT', () => shutdown('SIGINT'))
+}
+
+if (require.main === module) {
+  main()
+}

--- a/worker/src/server.ts
+++ b/worker/src/server.ts
@@ -1,0 +1,47 @@
+import type { IncomingMessage, ServerResponse, RequestListener } from 'http'
+import type { InngestFunction } from 'inngest'
+
+export interface WorkerServerDeps {
+  functions: InngestFunction.Any[]
+  /**
+   * Injected Inngest HTTP handler. In production `server.ts`'s entrypoint
+   * builds this from `serve({ client, functions })`. Tests pass a stub so the
+   * Inngest runtime doesn't have to be spun up.
+   */
+  serveHandler?: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>
+  /** Reports whether the Stockfish engine has finished its warm-up. */
+  getEngineWarm?: () => boolean
+}
+
+export function createRequestHandler(deps: WorkerServerDeps): RequestListener {
+  const { serveHandler, getEngineWarm } = deps
+
+  return (req, res) => {
+    const url = req.url ?? '/'
+
+    if (url === '/health' || url === '/healthz') {
+      const payload = {
+        status: 'ok',
+        engineWarm: getEngineWarm ? getEngineWarm() : false,
+      }
+      res.statusCode = 200
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify(payload))
+      return
+    }
+
+    if (url.startsWith('/api/inngest')) {
+      if (!serveHandler) {
+        res.statusCode = 503
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({ error: 'inngest handler not configured' }))
+        return
+      }
+      return serveHandler(req, res)
+    }
+
+    res.statusCode = 404
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ error: 'not found' }))
+  }
+}

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "..",
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "../lib/**/*.ts", "../types/**/*.ts"],
+  "exclude": ["node_modules", "dist", "../__tests__", "../app", "../components"]
+}


### PR DESCRIPTION
## Summary

Implements plan F from #74: moves the sync pipeline off Vercel serverless onto a persistent Fly.io worker so the 40MB Stockfish NNUE weights load **once at boot** instead of re-freezing the event loop on every invocation (root cause of #67).

Rolls in the chess.com rate-limit hardening that was scoped into the same PR.

### Slices (one commit each, TDD red→green per issue #74 process)

1. **Worker scaffolding** — `worker/` package, Node HTTP server, `/health`, Dockerfile, `fly.toml`.
2. **Register `syncGamesFunction`** on the worker via `inngest/node` `serve()`.
3. **Engine warm-up on boot** — `makeSyncGamesHandler({engineFactory})` + `createSyncGamesFunction({engineFactory})`; the worker calls `createDefaultEngine()` once and every job reuses the same instance. `/health` reports `engineWarm`.
4. **Chess.com hardening** — ETag/If-Modified-Since conditional fetches, 429 exp backoff (1/2/4/8s), `concurrency:{limit:3,key:'"chess-com"'}` on the Inngest function, new `chess_com_archives` table + RLS (migration 012, **pushed to prod Supabase**).
5. **Smoke-test checklist** — `worker/SMOKE_TEST.md`. Actual run is blocked on the Fly deploy happening first; the checklist is the DoD.
6. **Retire Vercel-side analysis** — `app/api/inngest/route.ts` now registers zero functions. The route stays as an empty `serve()` shell for future non-sync use.

### Numbers

- **388 tests passing, typecheck clean.**
- 17 chess.com client tests (up from 10) — ETag, 429 retry, cache plumbing.
- 6 new worker tests — server, functions, engine warm-up.

## Deploy order (critical)

**Do NOT merge this PR until the worker is live in Fly.io.** After merge, Vercel stops serving `sync/run`; if the worker isn't registered in Inngest first, syncs will fail.

1. `brew install flyctl && flyctl auth login`
2. `flyctl apps create chess-improver-worker`
3. `flyctl secrets set SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... INNGEST_EVENT_KEY=... INNGEST_SIGNING_KEY=... --app chess-improver-worker` (values from the Vercel project env)
4. `flyctl deploy --config worker/fly.toml --dockerfile worker/Dockerfile`
5. `curl https://chess-improver-worker.fly.dev/health` → `{"status":"ok","engineWarm":true}` (allow ~60s after boot)
6. Inngest dashboard → Apps → `chess-improver` → point the `sync-games` URL at the worker's `/api/inngest`.
7. **Now merge this PR.**
8. Run `worker/SMOKE_TEST.md` against `catalyst030119`.

## Test plan

- [x] `npm test` — 388 passing
- [x] `npm run typecheck` — clean (pre-existing playwright/review-session errors unchanged)
- [x] Supabase migration 012 applied to prod
- [ ] Fly deploy (operator)
- [ ] Inngest app URL re-pointed (operator)
- [ ] `worker/SMOKE_TEST.md` executed against catalyst030119 (operator)

## Related

- Fixes #67
- Supersedes the diagnostic bandaids in PRs #72, #73 (kept as cheap safety nets)
- Blocks #36 (real-time sync progress becomes meaningful once syncs actually complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)