### PR TITLE
Fix sync dashboard marking in-progress runs as 'Stuck' (closes #77)

### DIFF
--- a/__tests__/lib/sync-run-status.test.ts
+++ b/__tests__/lib/sync-run-status.test.ts
@@ -2,15 +2,20 @@
  * @jest-environment node
  */
 
-import { syncRunStatusLabel } from '@/lib/sync-run-status'
+import { syncRunStatusLabel, RUNNING_GRACE_MS } from '@/lib/sync-run-status'
 import type { SyncLog } from '@/types/database'
+
+const START = '2024-01-01T00:00:00Z'
+const START_MS = new Date(START).getTime()
+const FRESH = START_MS + 60_000 // 1 minute after start
+const STALE = START_MS + RUNNING_GRACE_MS + 60_000 // past the threshold
 
 function log(partial: Partial<SyncLog>): SyncLog {
   return {
     id: 's',
     user_id: 'u',
     mode: 'incremental',
-    started_at: '2024-01-01T00:00:00Z',
+    started_at: START,
     completed_at: null,
     games_processed: 0,
     cards_created: 0,
@@ -23,35 +28,65 @@ function log(partial: Partial<SyncLog>): SyncLog {
 
 describe('syncRunStatusLabel', () => {
   it('returns success when stage=complete and no error', () => {
-    expect(syncRunStatusLabel(log({ stage: 'complete' }))).toEqual({
+    expect(syncRunStatusLabel(log({ stage: 'complete' }), FRESH)).toEqual({
+      label: 'All stages green',
+      tone: 'success',
+    })
+  })
+
+  it('returns success when stage=complete even if completed_at never got set', () => {
+    // Observed during Plan F smoke test: worker finished, but the row's
+    // completed_at column stayed null. Stage is the source of truth.
+    expect(syncRunStatusLabel(log({ stage: 'complete', completed_at: null }), STALE)).toEqual({
       label: 'All stages green',
       tone: 'success',
     })
   })
 
   it('returns error when the server recorded an error message', () => {
-    expect(syncRunStatusLabel(log({ stage: 'error', error: 'Chess.com 404' }))).toEqual({
+    expect(syncRunStatusLabel(log({ stage: 'error', error: 'Chess.com 404' }), FRESH)).toEqual({
       label: 'Chess.com 404',
       tone: 'error',
     })
   })
 
   it('returns error with a fallback label when stage=error but no message', () => {
-    expect(syncRunStatusLabel(log({ stage: 'error' }))).toEqual({
+    expect(syncRunStatusLabel(log({ stage: 'error' }), FRESH)).toEqual({
       label: 'Sync failed',
       tone: 'error',
     })
   })
 
-  it('returns warn when stage is not terminal (run never finished)', () => {
-    expect(syncRunStatusLabel(log({ stage: 'analyzing' }))).toEqual({
+  it('returns info (still running) when a non-terminal run is within the grace window', () => {
+    expect(syncRunStatusLabel(log({ stage: 'analyzing' }), FRESH)).toEqual({
+      label: 'Still running…',
+      tone: 'info',
+    })
+  })
+
+  it('returns info for queued runs during the grace window', () => {
+    expect(syncRunStatusLabel(log({ stage: 'queued' }), FRESH)).toEqual({
+      label: 'Still running…',
+      tone: 'info',
+    })
+  })
+
+  it('returns info for legacy rows with no stage during the grace window', () => {
+    expect(syncRunStatusLabel(log({ stage: null }), FRESH)).toEqual({
+      label: 'Still running…',
+      tone: 'info',
+    })
+  })
+
+  it('returns warn (stuck) once a non-terminal run has aged past the grace window', () => {
+    expect(syncRunStatusLabel(log({ stage: 'analyzing' }), STALE)).toEqual({
       label: 'Run did not finish',
       tone: 'warn',
     })
   })
 
-  it('returns warn when stage is missing entirely (legacy rows)', () => {
-    expect(syncRunStatusLabel(log({ stage: null }))).toEqual({
+  it('returns warn for legacy rows with no stage once aged past the grace window', () => {
+    expect(syncRunStatusLabel(log({ stage: null }), STALE)).toEqual({
       label: 'Run did not finish',
       tone: 'warn',
     })
@@ -60,7 +95,7 @@ describe('syncRunStatusLabel', () => {
   it('prefers the explicit error message even if stage claims complete', () => {
     // Guards against weird race where completed_at was written with a
     // partial-failure error attached.
-    expect(syncRunStatusLabel(log({ stage: 'complete', error: 'Partial failure' }))).toEqual({
+    expect(syncRunStatusLabel(log({ stage: 'complete', error: 'Partial failure' }), FRESH)).toEqual({
       label: 'Partial failure',
       tone: 'error',
     })

--- a/app/sync/page.tsx
+++ b/app/sync/page.tsx
@@ -12,12 +12,14 @@ const TONE_DOT: Record<StatusTone, string> = {
   success: 'var(--good)',
   error: 'var(--amber)',
   warn: 'var(--amber)',
+  info: 'var(--muted)',
 }
 
 const TONE_TEXT: Record<StatusTone, string> = {
   success: 'var(--muted)',
   error: 'var(--ink-2)',
   warn: 'var(--ink-2)',
+  info: 'var(--ink-2)',
 }
 
 export default function SyncPage() {
@@ -89,16 +91,23 @@ export default function SyncPage() {
       ? 'Never synced.'
       : lastStatus!.tone === 'success'
         ? 'Everything in order.'
-        : lastStatus!.tone === 'warn'
-          ? 'Last run did not finish.'
-          : 'Last run stopped with an error.'
+        : lastStatus!.tone === 'info'
+          ? 'Sync in progress.'
+          : lastStatus!.tone === 'warn'
+            ? 'Last run did not finish.'
+            : 'Last run stopped with an error.'
   const heroSubtitle = status
     ? lastStatus!.tone === 'success'
       ? `Last run succeeded ${lastRunDate} at ${lastRun}. Nightly job scheduled for 02:14 UTC.`
-      : `Last run on ${lastRunDate} at ${lastRun} — ${lastStatus!.label}.`
+      : lastStatus!.tone === 'info'
+        ? `Started ${lastRunDate} at ${lastRun}. Stockfish analysis runs ~30-40s per game — check back in a few minutes.`
+        : `Last run on ${lastRunDate} at ${lastRun} — ${lastStatus!.label}.`
     : 'Run a historical import from the onboarding page first.'
   const lastStatusStat = lastStatus
-    ? lastStatus.tone === 'success' ? 'OK' : lastStatus.tone === 'warn' ? 'Stuck' : 'Error'
+    ? lastStatus.tone === 'success' ? 'OK'
+      : lastStatus.tone === 'info' ? 'Running'
+      : lastStatus.tone === 'warn' ? 'Stuck'
+      : 'Error'
     : '—'
 
   const lastSuccessful = history.find((h) => syncRunStatusLabel(h).tone === 'success')

--- a/lib/sync-run-status.ts
+++ b/lib/sync-run-status.ts
@@ -1,15 +1,24 @@
 import type { SyncLog } from '@/types/database'
 
-export type StatusTone = 'success' | 'error' | 'warn'
+export type StatusTone = 'success' | 'error' | 'warn' | 'info'
 
 export interface SyncRunStatus {
   label: string
   tone: StatusTone
 }
 
-export function syncRunStatusLabel(log: SyncLog): SyncRunStatus {
+// Generous threshold: real Stockfish analysis is ~30-40s/game, so a 16-game
+// run can legitimately take 10+ minutes. Only flag as stuck after this.
+export const RUNNING_GRACE_MS = 30 * 60 * 1000
+
+export function syncRunStatusLabel(log: SyncLog, now: number = Date.now()): SyncRunStatus {
   if (log.error) return { label: log.error, tone: 'error' }
   if (log.stage === 'complete') return { label: 'All stages green', tone: 'success' }
   if (log.stage === 'error') return { label: 'Sync failed', tone: 'error' }
+
+  const age = now - new Date(log.started_at).getTime()
+  if (age < RUNNING_GRACE_MS) {
+    return { label: 'Still running…', tone: 'info' }
+  }
   return { label: 'Run did not finish', tone: 'warn' }
 }


### PR DESCRIPTION
## What was wrong

During the Plan F smoke test the sync dashboard showed **"Last run did not finish"** / **"Stuck"** while the run was actually making progress — games were climbing 3 → 5 → 6, cards created had hit 125, and the run went on to complete successfully with 16/16 games.

The label logic in `lib/sync-run-status.ts` only knew three outcomes: success (stage=complete), error, or "did not finish" (anything else). With the new worker doing real Stockfish analysis (~30-40s per game), any run still mid-analysis got labeled as failed even though it was healthy.

## What this PR does

- Adds a fourth status tone — `info` — for "still running."
- Any non-terminal run (queued / fetching / analyzing / null stage) that started less than **30 minutes** ago now shows as **"Still running…"** in the history and **"Running"** in the stat card. The hero headline becomes **"Sync in progress."** with a subtitle explaining Stockfish timing.
- Only after 30 minutes without hitting a terminal stage does a run fall back to the old **"Stuck"** / **"Run did not finish"** labeling — that's still the right call for genuinely abandoned runs.
- `syncRunStatusLabel` already treated `stage = 'complete'` as success regardless of whether `completed_at` got written; added an explicit test to lock that in so the "finished but bookkeeping lagged" case stays correct.

No changes to the worker, sync pipeline, or DB schema — purely UI/label.

## Test plan

- [x] `npx jest __tests__/lib/sync-run-status.test.ts` — all 10 cases pass
- [ ] Kick off a sync from `/sync` and confirm the hero reads "Sync in progress." instead of "Last run did not finish." while it runs
- [ ] Confirm stat card reads "Running" during the run and flips to "OK" once it completes
- [ ] Old history rows (legacy null-stage or truly abandoned runs older than 30 min) still correctly show as "Stuck"

🤖 Generated with [Claude Code](https://claude.com/claude-code)