### PR TITLE
Tighten 'great' classification to cut opening-book noise (fixes #78)

### DIFF
--- a/__tests__/lib/move-classifier.test.ts
+++ b/__tests__/lib/move-classifier.test.ts
@@ -1,47 +1,69 @@
 import { classifyMove } from '@/lib/move-classifier'
 
+// Shorthand: the extra args (legalMoveCount, fullmove) matter only for 'great'.
+// For blunder/mistake tests, we pass permissive defaults.
+const MID = 15 // fullmove deep enough to clear the great-guard
+const WIDE = 20 // legal-move count high enough to clear the great-guard
+
 describe('classifyMove', () => {
   describe('blunder (CPL > 200)', () => {
     it('classifies a move as blunder when CPL is 201', () => {
-      expect(classifyMove(201, 'e4', 'd4', 20)).toBe('blunder')
+      expect(classifyMove(201, 'e4', 'd4', WIDE, MID)).toBe('blunder')
     })
   })
 
   describe('mistake (CPL 100–200)', () => {
     it('classifies a move as mistake when CPL is 150', () => {
-      expect(classifyMove(150, 'e4', 'd4', 20)).toBe('mistake')
+      expect(classifyMove(150, 'e4', 'd4', WIDE, MID)).toBe('mistake')
     })
   })
 
-  describe('great (matches engine top choice with alternatives)', () => {
-    it('classifies as great when move matches bestMove and alternatives exist', () => {
-      expect(classifyMove(0, 'e4', 'e4', 20)).toBe('great')
+  describe('great (tightened — issue #78)', () => {
+    it('classifies as great when move matches bestMove past opening with many alternatives and clean CPL', () => {
+      expect(classifyMove(0, 'e4', 'e4', WIDE, MID)).toBe('great')
+    })
+
+    it('does NOT flag great in opening (fullmove < 12) even if move matches bestMove', () => {
+      expect(classifyMove(0, 'e4', 'e4', WIDE, 1)).toBeNull()
+      expect(classifyMove(0, 'Nf3', 'Nf3', WIDE, 11)).toBeNull()
+    })
+
+    it('does NOT flag great when legal moves < 8 (forced/near-forced position)', () => {
+      expect(classifyMove(0, 'Kh1', 'Kh1', 7, MID)).toBeNull()
+    })
+
+    it('does NOT flag great when CPL > 10 (eval noise)', () => {
+      expect(classifyMove(11, 'e4', 'e4', WIDE, MID)).toBeNull()
+    })
+
+    it('allows great at exactly fullmove 12, legal=8, cpl=10 (boundary)', () => {
+      expect(classifyMove(10, 'e4', 'e4', 8, 12)).toBe('great')
     })
   })
 
   describe('edge cases', () => {
     it('CPL exactly 201 is a blunder', () => {
-      expect(classifyMove(201, 'e4', 'd4', 20)).toBe('blunder')
+      expect(classifyMove(201, 'e4', 'd4', WIDE, MID)).toBe('blunder')
     })
 
     it('CPL exactly 200 is a mistake, not a blunder', () => {
-      expect(classifyMove(200, 'e4', 'd4', 20)).toBe('mistake')
+      expect(classifyMove(200, 'e4', 'd4', WIDE, MID)).toBe('mistake')
     })
 
     it('CPL exactly 100 is a mistake', () => {
-      expect(classifyMove(100, 'e4', 'd4', 20)).toBe('mistake')
+      expect(classifyMove(100, 'e4', 'd4', WIDE, MID)).toBe('mistake')
     })
 
     it('CPL exactly 99 is null (unremarkable move)', () => {
-      expect(classifyMove(99, 'e4', 'd4', 20)).toBeNull()
+      expect(classifyMove(99, 'e4', 'd4', WIDE, MID)).toBeNull()
     })
 
     it('forced move (legalMoveCount=1) matching bestMove is null, not great', () => {
-      expect(classifyMove(0, 'e4', 'e4', 1)).toBeNull()
+      expect(classifyMove(0, 'e4', 'e4', 1, MID)).toBeNull()
     })
 
     it('move that does not match bestMove with low CPL is null', () => {
-      expect(classifyMove(50, 'e4', 'd4', 20)).toBeNull()
+      expect(classifyMove(50, 'e4', 'd4', WIDE, MID)).toBeNull()
     })
   })
 })

--- a/__tests__/lib/stockfish-analyzer.test.ts
+++ b/__tests__/lib/stockfish-analyzer.test.ts
@@ -174,15 +174,28 @@ describe('analyzeGame', () => {
       expect(result[0].classification).toBe('blunder')
     })
 
-    it('classifies a great move (matches bestMove, not forced) correctly', async () => {
-      // Use a position with many legal moves; movePlayed matches bestMove; CPL = 0
-      const positions: GamePosition[] = [{ fen: startFen, movePlayed: 'e4' }]
+    it('classifies a great move (past opening, many alternatives, clean CPL)', async () => {
+      // Fullmove counter bumped to 15 so the move clears the great-guard
+      // (fullmove >= 12) added in issue #78. Piece layout intentionally equals
+      // the starting position to keep 20 legal moves and make 'e2e4' legal.
+      const midgameFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 15'
+      const positions: GamePosition[] = [{ fen: midgameFen, movePlayed: 'e4' }]
       // CPL = max(0, 20 + (-25)) = 0; bestMove for evalBefore = 'e2e4' = movePlayed
       const result = await analyzeGame(
         positions,
         makeMockEngine([20, -25], ['e2e4']),
       )
       expect(result[0].classification).toBe('great')
+    })
+
+    it('does NOT classify an early-opening matched move as great (issue #78)', async () => {
+      // Same setup as above but at fullmove 1 — should NOT be flagged as great.
+      const positions: GamePosition[] = [{ fen: startFen, movePlayed: 'e4' }]
+      const result = await analyzeGame(
+        positions,
+        makeMockEngine([20, -25], ['e2e4']),
+      )
+      expect(result[0].classification).toBeNull()
     })
 
     it('returns null classification for an unremarkable move', async () => {

--- a/lib/move-classifier.ts
+++ b/lib/move-classifier.ts
@@ -1,13 +1,28 @@
 import type { CardClassification } from '@/types/database'
 
+// Tightened "great" thresholds — issue #78. Matching the engine's top move is
+// only a teaching moment when the position had room to go wrong: past opening
+// theory, with enough legal alternatives, and with a clean CPL.
+const GREAT_MIN_FULLMOVE = 12
+const GREAT_MIN_LEGAL_MOVES = 8
+const GREAT_MAX_CPL = 10
+
 export function classifyMove(
   cpl: number,
   movePlayed: string,
   bestMove: string,
   legalMoveCount: number,
+  fullmove: number,
 ): CardClassification | null {
   if (cpl > 200) return 'blunder'
   if (cpl >= 100) return 'mistake'
-  if (movePlayed === bestMove && legalMoveCount > 1) return 'great'
+  if (
+    movePlayed === bestMove &&
+    legalMoveCount >= GREAT_MIN_LEGAL_MOVES &&
+    fullmove >= GREAT_MIN_FULLMOVE &&
+    cpl <= GREAT_MAX_CPL
+  ) {
+    return 'great'
+  }
   return null
 }

--- a/lib/stockfish-analyzer.ts
+++ b/lib/stockfish-analyzer.ts
@@ -109,6 +109,12 @@ function legalMoveCount(fen: string): number {
   return new Chess(fen).moves().length
 }
 
+function fullmoveFromFen(fen: string): number {
+  const parts = fen.trim().split(/\s+/)
+  const n = parseInt(parts[parts.length - 1] ?? '', 10)
+  return Number.isFinite(n) ? n : 1
+}
+
 function uciToSan(fen: string, uciMove: string): string | null {
   try {
     const chess = new Chess(fen)
@@ -157,7 +163,8 @@ export async function analyzeGame(
     const cpl = Math.max(0, before.score + after.score)
     const moveCount = legalMoveCount(fen)
     const bestMoveSan = uciToSan(fen, before.bestMove) ?? before.bestMove
-    const classification = classifyMove(cpl, movePlayed, bestMoveSan, moveCount)
+    const fullmove = fullmoveFromFen(fen)
+    const classification = classifyMove(cpl, movePlayed, bestMoveSan, moveCount, fullmove)
 
     results.push({
       fen,

--- a/scripts/cleanup-noisy-great-cards.mjs
+++ b/scripts/cleanup-noisy-great-cards.mjs
@@ -1,0 +1,91 @@
+// One-shot cleanup for issue #78. Re-evaluates every existing `great` card
+// against the tightened thresholds (fullmove >= 12, legalMoveCount >= 8,
+// cpl <= 10) and deletes the ones that no longer qualify. Blunder and mistake
+// cards are untouched. Run with: `node scripts/cleanup-noisy-great-cards.mjs`
+//
+// Reads Supabase creds from .env.local. Pass --apply to actually delete;
+// default is a dry-run that just prints counts and a sample.
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { Chess } from 'chess.js'
+
+const GREAT_MIN_FULLMOVE = 12
+const GREAT_MIN_LEGAL_MOVES = 8
+const GREAT_MAX_CPL = 10
+
+const env = Object.fromEntries(
+  readFileSync(join(process.cwd(), '.env.local'), 'utf8')
+    .split('\n')
+    .filter((l) => l.includes('='))
+    .map((l) => l.split('=').map((s) => s.trim()))
+    .map(([k, ...v]) => [k, v.join('=')]),
+)
+const SUPABASE_URL = env.NEXT_PUBLIC_SUPABASE_URL
+const SRK = env.SUPABASE_SERVICE_ROLE_KEY
+if (!SUPABASE_URL || !SRK) throw new Error('Missing Supabase env vars')
+
+const apply = process.argv.includes('--apply')
+
+async function sb(path, init = {}) {
+  const res = await fetch(`${SUPABASE_URL}${path}`, {
+    ...init,
+    headers: {
+      apikey: SRK,
+      Authorization: `Bearer ${SRK}`,
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  })
+  if (!res.ok) throw new Error(`${res.status} ${await res.text()}`)
+  if (res.status === 204) return null
+  return res.json()
+}
+
+function fullmoveFromFen(fen) {
+  const n = parseInt(fen.trim().split(/\s+/).pop(), 10)
+  return Number.isFinite(n) ? n : 1
+}
+
+function legalMoveCount(fen) {
+  try { return new Chess(fen).moves().length } catch { return 0 }
+}
+
+function qualifiesAsGreat(card) {
+  const fm = fullmoveFromFen(card.fen)
+  const lm = legalMoveCount(card.fen)
+  const cpl = card.cpl ?? 999
+  return fm >= GREAT_MIN_FULLMOVE && lm >= GREAT_MIN_LEGAL_MOVES && cpl <= GREAT_MAX_CPL
+}
+
+const great = await sb('/rest/v1/cards?select=id,fen,cpl,correct_move,theme&classification=eq.great&limit=1000')
+console.log(`Total great cards: ${great.length}`)
+
+const toDelete = great.filter((c) => !qualifiesAsGreat(c))
+const toKeep = great.filter(qualifiesAsGreat)
+console.log(`Would delete: ${toDelete.length}`)
+console.log(`Would keep:   ${toKeep.length}`)
+
+console.log('\nSample to delete (first 5):')
+for (const c of toDelete.slice(0, 5)) {
+  console.log(`  fm=${fullmoveFromFen(c.fen)} lm=${legalMoveCount(c.fen)} cpl=${c.cpl} move=${c.correct_move} theme=${c.theme}`)
+}
+console.log('\nSample to keep (first 5):')
+for (const c of toKeep.slice(0, 5)) {
+  console.log(`  fm=${fullmoveFromFen(c.fen)} lm=${legalMoveCount(c.fen)} cpl=${c.cpl} move=${c.correct_move} theme=${c.theme}`)
+}
+
+if (!apply) {
+  console.log('\n(dry run — pass --apply to delete)')
+  process.exit(0)
+}
+
+console.log(`\nDeleting ${toDelete.length} cards...`)
+const batchSize = 50
+for (let i = 0; i < toDelete.length; i += batchSize) {
+  const batch = toDelete.slice(i, i + batchSize)
+  const ids = batch.map((c) => `"${c.id}"`).join(',')
+  await sb(`/rest/v1/cards?id=in.(${ids})`, { method: 'DELETE' })
+  console.log(`  deleted ${Math.min(i + batchSize, toDelete.length)}/${toDelete.length}`)
+}
+console.log('Done.')


### PR DESCRIPTION
## Summary

- `classifyMove` now requires `fullmove >= 12`, `legalMoveCount >= 8`, and `cpl <= 10` before tagging a move as `great`. Matching the engine's top move is only a teaching moment when the position had room to go wrong.
- `analyzeGame` parses fullmove from the FEN and passes it into the classifier. No pipeline, worker, or card-generation changes.
- Blunder (`cpl > 200`) and mistake (`cpl >= 100`) thresholds unchanged — their smoke-test rates were already reasonable (~2.4 cards/game each).
- `scripts/cleanup-noisy-great-cards.mjs` re-applies the new rules to existing cards in-place — no re-sync needed. Already applied to the smoke-test account: 355 → 230 cards (deleted 125 noisy greats). Script is idempotent and dry-runs by default.

## Why

The Plan F smoke test produced 279 `great` cards from 16 games, including the literal starting position (`e4` from move 1, labeled "GREAT — Opening -9 CP"). 104 of the 279 were in the opening phase (fullmove ≤ 12, theme=`opening`) — pure book theory, no teaching signal. The previous rule (`movePlayed === bestMove && legalMoveCount > 1`) had no notion of game phase, CPL noise, or move complexity.

## Card-count impact (smoke-test account)

| class | before | after |
|---|---|---|
| great | 279 | 154 |
| mistake | 38 | 38 |
| blunder | 38 | 38 |
| **total** | **355** | **230** |

That's ~14 cards/game down from ~22. The 154 surviving `great` cards are mostly mid/endgame tactical captures (e.g., `Bxd5`, `Nxe5`) where there are realistic alternatives.

## Test plan

- [x] `npx jest __tests__/lib/move-classifier.test.ts __tests__/lib/stockfish-analyzer.test.ts` — 33 passed
- [x] Dry-run cleanup script shows 125 deletions / 154 keeps
- [x] Applied to smoke-test account; Supabase now shows 230 cards with the expected class breakdown
- [ ] Review the 154 remaining `great` cards in the app and confirm signal-to-noise feels right. If still too noisy, follow-ups to consider: MultiPV-based "gap from 2nd best" filter, or a sequence-level "recovery after opponent mistake" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)