### PR TITLE
Land the piece on the target square when correct (fixes #81)

### DIFF
--- a/__tests__/components/ReviewBoard.test.tsx
+++ b/__tests__/components/ReviewBoard.test.tsx
@@ -9,6 +9,7 @@ type Outcome = 'firstTry' | 'afterHint' | 'afterAttempts' | 'failed';
 let capturedOnPieceDrop: (src: string, tgt: string) => boolean = () => false;
 let capturedCustomSquareStyles: Record<string, React.CSSProperties> = {};
 let capturedCustomArrows: Arrow[] = [];
+let capturedPosition: string = '';
 
 jest.mock('react-chessboard', () => ({
   Chessboard: ({
@@ -25,6 +26,7 @@ jest.mock('react-chessboard', () => ({
     capturedOnPieceDrop = onPieceDrop;
     capturedCustomSquareStyles = customSquareStyles ?? {};
     capturedCustomArrows = customArrows ?? [];
+    capturedPosition = position;
     return <div data-testid="chessboard" data-position={position} />;
   },
 }));
@@ -127,6 +129,29 @@ describe('ReviewBoard — Phase 15: Hint + Multi-Attempt Flow', () => {
     expect(onResult).toHaveBeenCalledWith('failed');
     // Arrow should show the correct move
     expect(capturedCustomArrows).toContainEqual([CORRECT_SOURCE, CORRECT_TARGET] as Arrow);
+  });
+
+  it('correct move lands the piece on the target square (issue #81)', () => {
+    const onResult = jest.fn<void, [Outcome]>();
+    render(
+      <ReviewBoard fen={STARTING_FEN} correctMove={CORRECT_MOVE} onResult={onResult} />
+    );
+    // Before the move: board shows the puzzle position.
+    expect(capturedPosition).toBe(STARTING_FEN);
+    act(() => { capturedOnPieceDrop(CORRECT_SOURCE, CORRECT_TARGET); });
+    // After the correct move: board advances to post-move FEN (pawn on e4).
+    expect(capturedPosition).not.toBe(STARTING_FEN);
+    expect(capturedPosition).toContain('4P3'); // pawn on e4 in rank 4
+  });
+
+  it('wrong move leaves the board on the original puzzle position', () => {
+    const onResult = jest.fn<void, [Outcome]>();
+    render(
+      <ReviewBoard fen={STARTING_FEN} correctMove={CORRECT_MOVE} onResult={onResult} />
+    );
+    act(() => { capturedOnPieceDrop(WRONG_SOURCE, WRONG_TARGET); });
+    // Board stays on the puzzle FEN so the piece snaps back.
+    expect(capturedPosition).toBe(STARTING_FEN);
   });
 
   it('board ignores moves after resolution', () => {

--- a/components/ReviewBoard.tsx
+++ b/components/ReviewBoard.tsx
@@ -28,6 +28,11 @@ export function ReviewBoard({ fen, correctMove, onResult, onWrongAttempt, boardO
   const [resolved, setResolved] = useState(false);
   const [hintSquare, setHintSquare] = useState<string | null>(null);
   const [revealArrow, setRevealArrow] = useState<Arrow | null>(null);
+  // When the correct move is played, we advance the rendered position to the
+  // post-move FEN so the piece visibly lands on the target square instead of
+  // snapping back to match the `fen` prop (issue #81). Wrong moves still snap
+  // back — the board stays on the puzzle position until resolved.
+  const [displayFen, setDisplayFen] = useState(fen);
 
   function onPieceDrop(sourceSquare: string, targetSquare: string): boolean {
     if (resolved) return false;
@@ -44,6 +49,7 @@ export function ReviewBoard({ fen, correctMove, onResult, onWrongAttempt, boardO
 
     if (move.san === correctMove) {
       setResolved(true);
+      setDisplayFen(chess.fen());
       if (attempts === 0) {
         onResult('firstTry');
       } else if (attempts === 1) {
@@ -76,7 +82,7 @@ export function ReviewBoard({ fen, correctMove, onResult, onWrongAttempt, boardO
 
   return (
     <Chessboard
-      position={fen}
+      position={displayFen}
       onPieceDrop={onPieceDrop}
       customSquareStyles={customSquareStyles}
       customArrows={customArrows}


### PR DESCRIPTION
## Summary

- ReviewBoard now advances its rendered position to the post-move FEN when the player plays the correct move, so the piece visibly lands on the target square instead of snapping home.
- Wrong moves still snap back — the puzzle position stays put until the player resolves it correctly.
- Added two tests covering both paths.

## Why

Getting a card right should *feel* right. Before this change, onPieceDrop returned true on a correct answer but the `position` prop was still the pre-move puzzle FEN, so react-chessboard reset the piece to match. The player's correct move bounced home right before the rating panel appeared — confusing and unrewarding.

## How

ReviewBoard now holds a local `displayFen` initialized from the `fen` prop. On a correct move we set it to `chess.fen()` (post-move). The parent already remounts ReviewBoard per card via `key={card.cardId}`, so `displayFen` reinitializes naturally on card change — no explicit reset needed.

## Test plan

- [x] `npx jest __tests__/components/ReviewBoard.test.tsx` — 10 passed
- [ ] Verify in-browser on the smoke-test account: correct moves land, wrong moves snap back, hints still show, rating panel still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)