### PR TITLE
Add best_move column to cards (chunk 1 of #86)

### DIFF
--- a/supabase/migrations/013_cards_best_move.sql
+++ b/supabase/migrations/013_cards_best_move.sql
@@ -1,0 +1,14 @@
+-- Migration: 013_cards_best_move
+-- Adds `best_move` (SAN) to the cards table. The analyzer already knows the
+-- engine's top move per position, but card-generator was discarding it and
+-- writing only `movePlayed` as `correct_move`. For blunder/mistake cards
+-- that means the stored "correct" answer is the user's own bad move (see
+-- issue #86). This column lets us persist the engine's recommendation so
+-- the review UI can ask the user to find the right move, and later issue
+-- #83 can generate a rationale for it.
+--
+-- Nullable: existing rows get NULL; the review flow falls back to
+-- `correct_move` when `best_move` is absent so nothing breaks during rollout.
+
+ALTER TABLE "cards"
+  ADD COLUMN IF NOT EXISTS "best_move" TEXT;


### PR DESCRIPTION
## Summary

Schema-only migration. Adds \`best_move TEXT\` (nullable) to the \`cards\` table.

Existing rows get NULL. No code reads or writes the column yet — later chunks wire up the analyzer/card-generator to populate it, and the review flow to prefer it over \`correct_move\` (with graceful fallback).

Already pushed to the remote database with \`supabase db push\` so the column is live before chunk 2 starts writing to it.

## Context

Chunk 1 of 4 for #86. See that issue for the full plan and the bug this unblocks (blunder/mistake cards currently store the user's own losing move as the \"correct\" answer).

## Test plan

- [x] \`supabase db push\` succeeded locally
- [x] Verified column exists in prod (\`curl\` to \`/rest/v1/cards?select=id,best_move\`)
- [ ] No app code change to test — subsequent chunks cover that

🤖 Generated with [Claude Code](https://claude.com/claude-code)