### PR TITLE
Persist engine's best move on new cards (chunk 2 of #86)

### DIFF
--- a/__tests__/lib/card-generator.test.ts
+++ b/__tests__/lib/card-generator.test.ts
@@ -6,7 +6,9 @@ import { generateCards, classifyTheme } from '@/lib/card-generator'
 import type { PositionAnalysis } from '@/lib/stockfish-analyzer'
 
 // Builds a fake database that remembers what cards already exist
-// and records what gets inserted
+// and records what gets inserted. Mirrors the Supabase query-builder shape:
+// `.from(t).insert(rows).select('id')` — `.insert` returns a builder, not a
+// Promise, so the follow-up `.select('id')` works.
 function makeMockDb(existingFens: string[] = []) {
   const insertedRows: Record<string, unknown>[] = []
   const db = {
@@ -22,7 +24,13 @@ function makeMockDb(existingFens: string[] = []) {
       }),
       insert: (rows: Record<string, unknown>[]) => {
         insertedRows.push(...rows)
-        return Promise.resolve({ data: rows, error: null })
+        return {
+          select: (_cols: string) =>
+            Promise.resolve({
+              data: rows.map((_r, i) => ({ id: `generated-${i}` })),
+              error: null,
+            }),
+        }
       },
     }),
   }
@@ -33,8 +41,17 @@ function makePosition(
   fen: string,
   movePlayed: string,
   classification: PositionAnalysis['classification'],
+  bestMoveSan?: string,
 ): PositionAnalysis {
-  return { fen, movePlayed, cpl: 0, bestMove: movePlayed, bestLine: [], classification }
+  return {
+    fen,
+    movePlayed,
+    cpl: 0,
+    bestMove: movePlayed,
+    bestMoveSan: bestMoveSan ?? movePlayed,
+    bestLine: [],
+    classification,
+  }
 }
 
 const FEN_A = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1'
@@ -57,6 +74,19 @@ describe('generateCards', () => {
       fen: FEN_A,
       correct_move: 'e5',
       classification: 'blunder',
+    })
+  })
+
+  it("persists the engine's best move so blunder/mistake cards have a correct answer (#86)", async () => {
+    const { db, insertedRows } = makeMockDb()
+    // User played 'e5' (a blunder); engine's top move was 'Nf3'.
+    const positions = [makePosition(FEN_A, 'e5', 'blunder', 'Nf3')]
+
+    await generateCards(positions, db as never)
+
+    expect(insertedRows[0]).toMatchObject({
+      correct_move: 'e5',   // the move played (legacy, still stored)
+      best_move: 'Nf3',     // the move the engine recommended (used by review UI post-#86)
     })
   })
 

--- a/__tests__/lib/stockfish-analyzer.test.ts
+++ b/__tests__/lib/stockfish-analyzer.test.ts
@@ -155,6 +155,16 @@ describe('analyzeGame', () => {
       expect(result[0].bestMove).toBe('e2e4')
     })
 
+    it('captures bestMoveSan (SAN-converted engine top move) — #86', async () => {
+      const positions: GamePosition[] = [{ fen: startFen, movePlayed: 'e4' }]
+      const result = await analyzeGame(
+        positions,
+        makeMockEngine([20, 10], ['e2e4']),
+      )
+      // UCI 'e2e4' on the starting position converts to SAN 'e4'
+      expect(result[0].bestMoveSan).toBe('e4')
+    })
+
     it('captures bestLine (PV) from engine output', async () => {
       const positions: GamePosition[] = [{ fen: startFen, movePlayed: 'e4' }]
       const result = await analyzeGame(

--- a/lib/card-generator.ts
+++ b/lib/card-generator.ts
@@ -58,6 +58,7 @@ export async function generateCards(
     const rows = toInsert.map((p) => ({
       fen: p.fen,
       correct_move: p.movePlayed,
+      best_move: p.bestMoveSan,
       classification: p.classification,
       theme: classifyTheme(p.fen),
       note: null,

--- a/lib/stockfish-analyzer.ts
+++ b/lib/stockfish-analyzer.ts
@@ -8,6 +8,11 @@ export interface PositionAnalysis {
   movePlayed: string
   cpl: number
   bestMove: string
+  /** Engine's top move in SAN (e.g. "Nxe5"). `bestMove` is UCI; card-generator
+   * persists this field as `best_move` so blunder/mistake cards can surface
+   * the engine's recommendation rather than the user's own losing move
+   * (see issue #86). */
+  bestMoveSan: string
   bestLine: string[]
   classification: CardClassification | null
 }
@@ -164,6 +169,7 @@ export async function analyzeGame(
       movePlayed,
       cpl,
       bestMove: before.bestMove,
+      bestMoveSan,
       bestLine: before.bestLine,
       classification,
     })


### PR DESCRIPTION
## Summary

- Analyzer now exposes \`bestMoveSan\` (SAN of engine's top move) on \`PositionAnalysis\`. The value was already computed internally for classification — just wasn't in the output shape.
- Card-generator writes \`best_move: p.bestMoveSan\` into the column added by [#87](https://github.com/moscowac-source/chess_game_reviewer/pull/87). New cards now record both the played move (\`correct_move\`, legacy) and the engine's recommendation (\`best_move\`).
- Fixed a pre-existing test-mock bug: the fake Supabase client's \`.insert()\` returned a raw Promise, but the real shape is \`.insert(rows).select('id')\`. 8 existing tests in card-generator.test.ts had been silently failing on \`main\` as a result — now pass alongside the two new ones for chunk 2.

## Why

Chunk 2 of 4 for [#86](https://github.com/moscowac-source/chess_game_reviewer/issues/86). This populates the new column going forward. Still not user-visible — chunk 3 updates the review flow to read from it.

## Depends on

[#87](https://github.com/moscowac-source/chess_game_reviewer/pull/87) (the migration). This PR will write nulls into a non-existent column if it merges first, so land #87 first. The column is already live in prod via \`supabase db push\`, so writes will succeed even before #87 hits main.

## Test plan

- [x] \`npx jest __tests__/lib/card-generator.test.ts __tests__/lib/stockfish-analyzer.test.ts\` — 34 passed (was 15/23 before the mock fix)
- [ ] After merge + deploy, trigger a sync on the smoke-test account and confirm new cards have \`best_move\` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)