### PR TITLE
Chunk 3 of #86: review flow uses best_move with fallback

### DIFF
--- a/__tests__/lib/review-session-manager.test.ts
+++ b/__tests__/lib/review-session-manager.test.ts
@@ -272,6 +272,54 @@ describe('buildReviewSession', () => {
     })
   })
 
+  // -------------------------------------------------------------------------
+  // Issue #86: correctMove prefers best_move (engine's move) over correct_move
+  // (the user's played move, which is the wrong answer for blunder/mistake
+  // cards). Falls back to correct_move when best_move is null for cards
+  // inserted before the best_move column was populated.
+  // -------------------------------------------------------------------------
+  it('uses best_move as correctMove when present', async () => {
+    const cardStates: Row[] = [
+      { card_id: 'card-1', user_id: USER, state: 'review', due_date: PAST, stability: 5, difficulty: 3, review_count: 2 },
+    ]
+    const cards: Row[] = [
+      { id: 'card-1', fen: 'fen1', correct_move: 'e5', best_move: 'Nf3', classification: 'blunder' },
+    ]
+    const { db } = makeMockDb(cardStates, cards)
+
+    const session = await buildReviewSession(USER, db as never)
+
+    expect(session.cards[0].correctMove).toBe('Nf3')
+  })
+
+  it('falls back to correct_move when best_move is null (legacy cards)', async () => {
+    const cardStates: Row[] = [
+      { card_id: 'card-1', user_id: USER, state: 'review', due_date: PAST, stability: 5, difficulty: 3, review_count: 2 },
+    ]
+    const cards: Row[] = [
+      { id: 'card-1', fen: 'fen1', correct_move: 'e4', best_move: null, classification: 'blunder' },
+    ]
+    const { db } = makeMockDb(cardStates, cards)
+
+    const session = await buildReviewSession(USER, db as never)
+
+    expect(session.cards[0].correctMove).toBe('e4')
+  })
+
+  it('falls back to correct_move when best_move is absent (legacy cards)', async () => {
+    const cardStates: Row[] = [
+      { card_id: 'card-1', user_id: USER, state: 'review', due_date: PAST, stability: 5, difficulty: 3, review_count: 2 },
+    ]
+    const cards: Row[] = [
+      { id: 'card-1', fen: 'fen1', correct_move: 'e4', classification: 'blunder' },
+    ]
+    const { db } = makeMockDb(cardStates, cards)
+
+    const session = await buildReviewSession(USER, db as never)
+
+    expect(session.cards[0].correctMove).toBe('e4')
+  })
+
   // =========================================================================
   // Phase 17: Quiz Modes — Filtered Sessions
   // =========================================================================

--- a/lib/review-session-manager.ts
+++ b/lib/review-session-manager.ts
@@ -42,6 +42,7 @@ type RawCard = {
   id: string
   fen: string
   correct_move: string
+  best_move?: string | null
   classification: CardClassification
   game_played_at?: string | null
   theme?: string | null
@@ -138,7 +139,7 @@ export async function buildReviewSession(
   const cards: SessionCard[] = filteredCardData.map((c) => ({
     cardId: c.id,
     fen: c.fen,
-    correctMove: c.correct_move,
+    correctMove: c.best_move ?? c.correct_move,
     classification: c.classification,
     isNew: !dueIds.has(c.id),
     theme: c.theme ?? null,


### PR DESCRIPTION
## Summary
- `lib/review-session-manager.ts` now maps `correctMove` from `cards.best_move` when present, falling back to `cards.correct_move` for legacy cards.
- Resolution happens in the manager layer — `SessionCard` and `ReviewBoard` stay unchanged. Minimum surface-area fix.
- After chunk 4's nuke + re-sync, the fallback path won't be hit by any fresh data, but stays as a safety net.

Part of #86. Chunks 1 ([#87](https://github.com/moscowac-source/chess_game_reviewer/pull/87)) and 2 ([#88](https://github.com/moscowac-source/chess_game_reviewer/pull/88)) have landed; chunk 4 (nuke + re-sync) is next.

## Test plan
- [x] New unit tests: `correctMove` prefers `best_move` when present
- [x] New unit tests: falls back to `correct_move` when `best_move` is null or absent
- [x] All 16 review-session-manager tests pass
- [x] No new tsc errors (2 pre-existing ones on main are unrelated)
- [ ] After chunk 4 re-sync, manually verify a blunder card's review shows the engine's best move as correct