### PR TITLE
Make hint highlight + reveal arrow readable on dark squares (fixes #82)

### DIFF
--- a/__tests__/components/ReviewBoard.test.tsx
+++ b/__tests__/components/ReviewBoard.test.tsx
@@ -94,6 +94,20 @@ describe('ReviewBoard — Phase 15: Hint + Multi-Attempt Flow', () => {
     expect(capturedCustomSquareStyles[CORRECT_SOURCE]).toBeDefined();
   });
 
+  it('hint highlight uses an inset ring so it reads on dark squares (issue #82)', () => {
+    const onResult = jest.fn<void, [Outcome]>();
+    render(
+      <ReviewBoard fen={STARTING_FEN} correctMove={CORRECT_MOVE} onResult={onResult} />
+    );
+    act(() => { capturedOnPieceDrop(WRONG_SOURCE, WRONG_TARGET); });
+    const style = capturedCustomSquareStyles[CORRECT_SOURCE];
+    expect(style).toBeDefined();
+    // Must use boxShadow (an inset ring), not a translucent `background`
+    // fill that blends with the underlying square color.
+    expect(style.boxShadow).toMatch(/inset/);
+    expect(style.background).toBeUndefined();
+  });
+
   it("correct on attempt 2 emits 'afterHint'", () => {
     const onResult = jest.fn<void, [Outcome]>();
     render(

--- a/components/ReviewBoard.tsx
+++ b/components/ReviewBoard.tsx
@@ -74,8 +74,11 @@ export function ReviewBoard({ fen, correctMove, onResult, onWrongAttempt, boardO
     return true;
   }
 
+  // Inset ring reads clearly on both light and dark squares — a translucent
+  // fill blended with the underlying square color (the old approach) was
+  // near-invisible on dark squares (issue #82).
   const customSquareStyles: Record<string, React.CSSProperties> = hintSquare
-    ? { [hintSquare]: { background: 'rgba(212,165,116,0.55)' } }
+    ? { [hintSquare]: { boxShadow: 'inset 0 0 0 4px var(--amber)' } }
     : {};
 
   const customArrows: Arrow[] = revealArrow ? [revealArrow] : [];
@@ -86,6 +89,7 @@ export function ReviewBoard({ fen, correctMove, onResult, onWrongAttempt, boardO
       onPieceDrop={onPieceDrop}
       customSquareStyles={customSquareStyles}
       customArrows={customArrows}
+      customArrowColor="#8b6f47"
       boardOrientation={boardOrientation}
       customBoardStyle={{
         boxShadow: '0 30px 60px -30px rgba(26,26,26,0.35)',


### PR DESCRIPTION
Re-opens [#85](https://github.com/moscowac-source/chess_game_reviewer/pull/85), which was auto-closed when its base branch (`fix-81-correct-move-lands`) was deleted as part of merging #84. Same code as #85, just rebased onto current main.

## Summary

- Swapped the hint-square highlight from a translucent amber fill (rgba 55% alpha) to an inset `box-shadow` ring in `--amber`. Renders on top of the underlying square color so it reads clearly on both light and dark squares while staying in palette.
- Set `customArrowColor` to walnut hex (`#8b6f47`) so the "3 wrong attempts" reveal arrow stops being default-red and matches the rest of the UI.

## Test plan

- [x] `npx jest __tests__/components/ReviewBoard.test.tsx` — passes
- [ ] Visual check on smoke-test account: hint readable on both square colors; reveal arrow is warm-toned, not red

🤖 Generated with [Claude Code](https://claude.com/claude-code)