### PR TITLE
Make hidden sync failures visible (issue #68)

### DIFF
--- a/__tests__/lib/card-generator.test.ts
+++ b/__tests__/lib/card-generator.test.ts
@@ -65,7 +65,7 @@ describe('generateCards', () => {
     const { db, insertedRows } = makeMockDb()
     const positions = [makePosition(FEN_A, 'e5', 'blunder')]
 
-    const result = await generateCards(positions, db as never)
+    const result = await generateCards(positions, db as never, 'game-1')
 
     expect(result.created).toBe(1)
     expect(result.skipped).toBe(0)
@@ -82,7 +82,7 @@ describe('generateCards', () => {
     // User played 'e5' (a blunder); engine's top move was 'Nf3'.
     const positions = [makePosition(FEN_A, 'e5', 'blunder', 'Nf3')]
 
-    await generateCards(positions, db as never)
+    await generateCards(positions, db as never, 'game-1')
 
     expect(insertedRows[0]).toMatchObject({
       correct_move: 'e5',   // the move played (legacy, still stored)
@@ -114,7 +114,7 @@ describe('generateCards', () => {
       makePosition(FEN_B, 'Nf3', 'mistake'),
     ]
 
-    const result = await generateCards(positions, db as never)
+    const result = await generateCards(positions, db as never, 'game-1')
 
     expect(result.created).toBe(2)
     expect(result.skipped).toBe(0)
@@ -147,7 +147,7 @@ describe('generateCards', () => {
       makePosition(ENDGAME_FEN, 'Kd6', 'mistake'),
     ]
 
-    await generateCards(positions, db as never)
+    await generateCards(positions, db as never, 'game-1')
 
     expect(insertedRows).toHaveLength(2)
     expect(insertedRows.find((r) => r.fen === OPENING_FEN)).toMatchObject({
@@ -162,7 +162,7 @@ describe('generateCards', () => {
     const { db, insertedRows } = makeMockDb()
     const positions = [makePosition(FEN_A, 'e5', 'blunder')]
 
-    await generateCards(positions, db as never)
+    await generateCards(positions, db as never, 'game-1')
 
     expect(insertedRows).toHaveLength(1)
     expect(insertedRows[0]).toHaveProperty('note', null)
@@ -179,14 +179,25 @@ describe('generateCards', () => {
     expect(insertedRows[0]).toMatchObject({ game_id: 'game-abc' })
   })
 
-  it('writes game_id as null on each new card when no gameId is supplied', async () => {
+  // Issue #68: cards must never be inserted with a null game_id. Inserting a
+  // new card without a gameId now throws rather than orphaning the card.
+  it('throws rather than inserting a card with a null game_id', async () => {
     const { db, insertedRows } = makeMockDb()
     const positions = [makePosition(FEN_A, 'e5', 'blunder')]
 
-    await generateCards(positions, db as never)
+    await expect(generateCards(positions, db as never)).rejects.toThrow(/game_id/)
+    expect(insertedRows).toHaveLength(0)
+  })
 
-    expect(insertedRows).toHaveLength(1)
-    expect(insertedRows[0]).toHaveProperty('game_id', null)
+  it('does not require a gameId when there are no new cards to insert', async () => {
+    const { db, insertedRows } = makeMockDb([FEN_A])
+    const positions = [makePosition(FEN_A, 'e5', 'blunder')]
+
+    const result = await generateCards(positions, db as never)
+
+    expect(result.created).toBe(0)
+    expect(result.skipped).toBe(1)
+    expect(insertedRows).toHaveLength(0)
   })
 
   // Issue #29: the cpl value from the PositionAnalysis is persisted on the card
@@ -202,7 +213,7 @@ describe('generateCards', () => {
       classification: 'blunder',
     }
 
-    await generateCards([position], db as never)
+    await generateCards([position], db as never, 'game-1')
 
     expect(insertedRows).toHaveLength(1)
     expect(insertedRows[0]).toMatchObject({ cpl: 310 })
@@ -220,7 +231,7 @@ describe('generateCards', () => {
       makePosition(FEN_C, 'Nc6', 'great'),
     ]
 
-    const result = await generateCards(positions, db as never)
+    const result = await generateCards(positions, db as never, 'game-1')
 
     expect(result.created).toBe(2)
     expect(result.skipped).toBe(1)

--- a/__tests__/lib/inngest-engine-warmup.test.ts
+++ b/__tests__/lib/inngest-engine-warmup.test.ts
@@ -41,7 +41,7 @@ const mockedRunSync = runSync as jest.MockedFunction<typeof runSync>
 describe('makeSyncGamesHandler — engine warm-up', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedRunSync.mockResolvedValue({ gamesProcessed: 1, cardsCreated: 0, errors: [] })
+    mockedRunSync.mockResolvedValue({ gamesProcessed: 1, gamesFailed: 0, cardsCreated: 0, errors: [] })
   })
 
   it('forwards an injected engineFactory into runSync so the worker can share one warm engine across jobs', async () => {

--- a/__tests__/lib/inngest-sync-games-handler.test.ts
+++ b/__tests__/lib/inngest-sync-games-handler.test.ts
@@ -41,7 +41,7 @@ const mockedRunSync = runSync as jest.MockedFunction<typeof runSync>
 describe('syncGamesHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedRunSync.mockResolvedValue({ gamesProcessed: 3, cardsCreated: 5, errors: [] })
+    mockedRunSync.mockResolvedValue({ gamesProcessed: 3, gamesFailed: 0, cardsCreated: 5, errors: [] })
   })
 
   it('forwards the Inngest step object into runSync so per-game work is memoized across retries', async () => {

--- a/__tests__/lib/sync-orchestrator.test.ts
+++ b/__tests__/lib/sync-orchestrator.test.ts
@@ -52,9 +52,12 @@ function makeLoggerSpy(): { logger: SyncLogger; calls: { started: number; comple
 
 beforeEach(() => {
   jest.clearAllMocks()
-  // Sensible defaults — tests override as needed
+  // Sensible defaults — tests override as needed. parseGame returns one
+  // position by default so the happy path produces a non-empty game; a game
+  // that parses to zero positions is now treated as a failure (#68), so tests
+  // that want that case override mockedParse explicitly.
   mockedHeaders.mockReturnValue({ ...EMPTY_HEADERS })
-  mockedParse.mockReturnValue([])
+  mockedParse.mockReturnValue([{ fen: 'FEN', movePlayed: 'e4' }])
   mockedAnalyze.mockResolvedValue([])
   mockedGenerate.mockResolvedValue({ created: 0, skipped: 0 })
 })
@@ -72,10 +75,10 @@ describe('runSync', () => {
       syncLogger: logger,
     })
 
-    expect(result).toEqual({ gamesProcessed: 0, cardsCreated: 0, errors: [] })
+    expect(result).toEqual({ gamesProcessed: 0, gamesFailed: 0, cardsCreated: 0, errors: [] })
     expect(calls.started).toBe(1)
     expect(calls.completed).toEqual([
-      { id: 'log-id-1', result: { gamesProcessed: 0, cardsCreated: 0, errors: [] } },
+      { id: 'log-id-1', result: { gamesProcessed: 0, gamesFailed: 0, cardsCreated: 0, errors: [] } },
     ])
   })
 
@@ -97,7 +100,7 @@ describe('runSync', () => {
       syncLogger: logger,
     })
 
-    expect(result).toEqual({ gamesProcessed: 1, cardsCreated: 1, errors: [] })
+    expect(result).toEqual({ gamesProcessed: 1, gamesFailed: 0, cardsCreated: 1, errors: [] })
     expect(inserted.games).toHaveLength(1)
     expect(inserted.games[0]).toMatchObject({
       user_id: USER_ID,
@@ -107,7 +110,7 @@ describe('runSync', () => {
     })
     const insertedGameId = inserted.games[0].id as string
     expect(mockedGenerate).toHaveBeenCalledWith(expect.any(Array), db, insertedGameId, USER_ID)
-    expect(calls.completed[0].result).toEqual({ gamesProcessed: 1, cardsCreated: 1, errors: [] })
+    expect(calls.completed[0].result).toEqual({ gamesProcessed: 1, gamesFailed: 0, cardsCreated: 1, errors: [] })
   })
 
   it('short-circuits when a games row with the same url already exists: reuses the existing id and does not insert', async () => {
@@ -153,10 +156,12 @@ describe('runSync', () => {
     })
 
     expect(result.gamesProcessed).toBe(1)
+    expect(result.gamesFailed).toBe(1)
     expect(result.cardsCreated).toBe(2)
     expect(result.errors).toEqual(['bad pgn'])
     expect(calls.completed[0].result).toEqual({
       gamesProcessed: 1,
+      gamesFailed: 1,
       cardsCreated: 2,
       errors: ['bad pgn'],
     })
@@ -179,7 +184,7 @@ describe('runSync', () => {
     expect(calls.started).toBe(1)
     expect(calls.completed).toHaveLength(1)
     expect(calls.completed[0].id).toBe('log-id-1')
-    expect(calls.completed[0].result).toEqual({ gamesProcessed: 1, cardsCreated: 5, errors: [] })
+    expect(calls.completed[0].result).toEqual({ gamesProcessed: 1, gamesFailed: 0, cardsCreated: 5, errors: [] })
   })
 
   it('invokes onProgress with stage + counts: fetching → analyzing → per-game → complete', async () => {
@@ -359,6 +364,98 @@ describe('runSync', () => {
   })
 
   // -------------------------------------------------------------------------
+  // #68 — silent bail paths must surface as failures / skips, not clean 'ok'
+  // -------------------------------------------------------------------------
+
+  describe('silent-bail surfacing (#68)', () => {
+    function makeStepSpy(): { logger: StepLogger; events: SyncStepEvent[] } {
+      const events: SyncStepEvent[] = []
+      const logger: StepLogger = async (e) => { events.push(e) }
+      return { logger, events }
+    }
+
+    it('treats a game that parses to zero positions as a failure, not a clean success', async () => {
+      const { db } = makeMockDb()
+      const { logger, events } = makeStepSpy()
+
+      mockedParse.mockReturnValue([]) // empty position list — broken game
+
+      const result = await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: async () => ['<pgn>'],
+        stepLogger: logger,
+      })
+
+      expect(result.gamesProcessed).toBe(0)
+      expect(result.gamesFailed).toBe(1)
+      expect(result.errors).toHaveLength(1)
+
+      // parse-positions must NOT log a green 'ok' for a zero-position game.
+      const parsePositions = events.find((e) => e.step === 'parse-positions')!
+      expect(parsePositions.status).toBe('error')
+
+      // The summary row reflects the failure rather than looking clean.
+      const endRow = events.find((e) => e.step === 'sync-end')!
+      expect(endRow.status).toBe('error')
+      expect(endRow.details).toMatchObject({ gamesProcessed: 0, gamesFailed: 1, errorCount: 1 })
+    })
+
+    it("logs generate-cards as 'skipped' (not 'ok') when a game yields no cards", async () => {
+      const { db } = makeMockDb()
+      const { logger, events } = makeStepSpy()
+
+      mockedParse.mockReturnValue([{ fen: 'FEN', movePlayed: 'e4' }])
+      mockedGenerate.mockResolvedValue({ created: 0, skipped: 0 })
+
+      const result = await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: async () => ['<pgn>'],
+        stepLogger: logger,
+      })
+
+      // The game still counts as processed (it was analyzed; just no cards).
+      expect(result.gamesProcessed).toBe(1)
+      expect(result.gamesFailed).toBe(0)
+
+      const generate = events.find((e) => e.step === 'generate-cards')!
+      expect(generate.status).toBe('skipped')
+      expect(generate.details).toMatchObject({ created: 0, skipped: 0 })
+    })
+
+    it("marks the summary row 'error' when some games fail even though others succeed", async () => {
+      const { db } = makeMockDb()
+      const { logger, events } = makeStepSpy()
+
+      let call = 0
+      mockedParse.mockImplementation(() => {
+        call++
+        if (call === 1) return [] // first game broken
+        return [{ fen: 'FEN', movePlayed: 'e4' }]
+      })
+      mockedGenerate.mockResolvedValue({ created: 1, skipped: 0 })
+
+      const result = await runSync('historical', {
+        username: 'player',
+        userId: USER_ID,
+        db,
+        gamesFetcher: async () => ['<bad>', '<good>'],
+        stepLogger: logger,
+      })
+
+      expect(result.gamesProcessed).toBe(1)
+      expect(result.gamesFailed).toBe(1)
+
+      const endRow = events.find((e) => e.step === 'sync-end')!
+      expect(endRow.status).toBe('error')
+      expect(endRow.details).toMatchObject({ gamesProcessed: 1, gamesFailed: 1, errorCount: 1 })
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // step runner — Inngest-style memoization of expensive phases
   // -------------------------------------------------------------------------
 
@@ -469,7 +566,7 @@ describe('runSync', () => {
       // both game steps were attempted (neither propagated out of step.run)
       expect(calls.filter((c) => c.id === 'process-game-0')).toHaveLength(1)
       expect(calls.filter((c) => c.id === 'process-game-1')).toHaveLength(1)
-      expect(result).toEqual({ gamesProcessed: 1, cardsCreated: 2, errors: ['bad pgn'] })
+      expect(result).toEqual({ gamesProcessed: 1, gamesFailed: 1, cardsCreated: 2, errors: ['bad pgn'] })
     })
 
     it('returns memoized fetch-archives output on replay without re-invoking the fetcher', async () => {

--- a/lib/card-generator.ts
+++ b/lib/card-generator.ts
@@ -55,6 +55,13 @@ export async function generateCards(
 
   const insertedIds: string[] = []
   if (toInsert.length > 0) {
+    // Cards must belong to a game. Refuse to insert with a null game_id —
+    // orphaned cards can't be traced back to the game they came from and were
+    // a silent failure mode of the sync pipeline (#68). The orchestrator
+    // always supplies a real id; this guard protects every other caller too.
+    if (gameId === null || gameId === undefined) {
+      throw new Error('generateCards: cannot insert cards without a game_id')
+    }
     const rows = toInsert.map((p) => ({
       fen: p.fen,
       correct_move: p.movePlayed,
@@ -63,7 +70,7 @@ export async function generateCards(
       theme: classifyTheme(p.fen),
       note: null,
       cpl: p.cpl,
-      game_id: gameId ?? null,
+      game_id: gameId,
     }))
     const { data: newRows, error: insertError } = await db
       .from('cards')

--- a/lib/sync-orchestrator.ts
+++ b/lib/sync-orchestrator.ts
@@ -7,6 +7,13 @@ import { generateCards } from './card-generator'
 export interface SyncResult {
   gamesProcessed: number
   cardsCreated: number
+  /**
+   * Count of games that hit a per-game error (broken PGN, empty position list,
+   * analyzer crash, etc.). Mirrors `errors.length` but is surfaced as an
+   * explicit top-line counter so a sync can never look clean (`gamesProcessed`
+   * fine, no visible problem) while the step log is full of failures. See #68.
+   */
+  gamesFailed: number
   errors: string[]
 }
 
@@ -138,7 +145,7 @@ async function ensureGameRow(
   userId: string,
   pgn: string,
   headers: PgnHeaders,
-): Promise<string | null> {
+): Promise<string> {
   if (headers.url) {
     const { data: existing } = await db
       .from('games')
@@ -166,30 +173,52 @@ async function ensureGameRow(
     .single()
 
   if (error) throw error
-  return inserted?.id ?? null
+  // A successful insert must yield an id. If it somehow doesn't, fail loudly
+  // here rather than returning null and letting downstream card generation
+  // insert cards with a null game_id (the silent bail in #68).
+  if (!inserted?.id) {
+    throw new Error('ensureGameRow: insert succeeded but returned no game id')
+  }
+  return inserted.id
 }
 
 /**
  * Runs `fn`, emits exactly one step-log row describing the outcome, and
  * returns the value (or rethrows the original error). Timing is measured in
  * whole milliseconds.
+ *
+ * `zeroWork` lets a step report that it ran cleanly but produced nothing
+ * useful (e.g. card generation found zero card-worthy positions). When it
+ * returns true the row is logged as `skipped` rather than `ok`, so the audit
+ * log never shows a green `ok` for a step that did no work (#68).
+ * `detailsFromResult` lets the row carry result-derived counts in `details`.
  */
 async function runStep<T>(
   stepLogger: StepLogger | undefined,
-  meta: { step: SyncStep; gameUrl?: string | null; gameIndex?: number | null; detailsOnOk?: Record<string, unknown> },
+  meta: {
+    step: SyncStep
+    gameUrl?: string | null
+    gameIndex?: number | null
+    detailsOnOk?: Record<string, unknown>
+    zeroWork?: (value: T) => boolean
+    detailsFromResult?: (value: T) => Record<string, unknown> | null
+  },
   fn: () => Promise<T> | T,
 ): Promise<T> {
   const start = Date.now()
   try {
     const value = await fn()
     if (stepLogger) {
+      const isZeroWork = meta.zeroWork ? meta.zeroWork(value) : false
+      const fromResult = meta.detailsFromResult ? meta.detailsFromResult(value) : null
+      const merged = { ...(meta.detailsOnOk ?? {}), ...(fromResult ?? {}) }
       await stepLogger({
         step: meta.step,
-        status: 'ok',
+        status: isZeroWork ? 'skipped' : 'ok',
         gameUrl: meta.gameUrl ?? null,
         gameIndex: meta.gameIndex ?? null,
         durationMs: Date.now() - start,
-        details: meta.detailsOnOk ?? null,
+        details: Object.keys(merged).length > 0 ? merged : null,
       })
     }
     return value
@@ -258,6 +287,7 @@ export async function runSync(
   })
 
   let gamesProcessed = 0
+  let gamesFailed = 0
   let cardsCreated = 0
   const errors: string[] = []
 
@@ -286,8 +316,17 @@ export async function runSync(
 
         const positions = await runStep(
           stepLogger,
-          { step: 'parse-positions', gameUrl, gameIndex },
-          () => parseGame(pgn),
+          { step: 'parse-positions', gameIndex, gameUrl, detailsFromResult: (p) => ({ positions: p.length }) },
+          () => {
+            const parsed = parseGame(pgn)
+            // A game that parses to zero positions is broken (malformed PGN or
+            // a parser bug) — fail it loudly instead of letting empty analysis
+            // and zero cards flow through as a clean success (#68).
+            if (parsed.length === 0) {
+              throw new Error('Game produced no analyzable positions (empty or unparseable PGN)')
+            }
+            return parsed
+          },
         )
 
         const gameId = await runStep(
@@ -309,7 +348,16 @@ export async function runSync(
 
         const result = await runStep(
           stepLogger,
-          { step: 'generate-cards', gameUrl, gameIndex },
+          {
+            step: 'generate-cards',
+            gameUrl,
+            gameIndex,
+            // A game can legitimately yield no cards (no blunders/mistakes), but
+            // that step did no work — log it as `skipped`, not `ok`, so the
+            // audit log stays honest (#68).
+            zeroWork: (r) => r.created === 0 && r.skipped === 0,
+            detailsFromResult: (r) => ({ created: r.created, skipped: r.skipped }),
+          },
           () => generateCards(analyses, db, gameId, userId),
         )
 
@@ -324,6 +372,7 @@ export async function runSync(
 
     if (gameResult.error !== undefined) {
       errors.push(gameResult.error)
+      gamesFailed++
     } else {
       gamesProcessed++
       cardsCreated += gameResult.cardsCreated ?? 0
@@ -337,7 +386,7 @@ export async function runSync(
     })
   }
 
-  const syncResult = { gamesProcessed, cardsCreated, errors }
+  const syncResult = { gamesProcessed, gamesFailed, cardsCreated, errors }
 
   if (logId) {
     await syncLogger?.logComplete(logId, syncResult)
@@ -345,10 +394,15 @@ export async function runSync(
 
   if (stepLogger) {
     await stepLogger({
+      // The summary row must reflect failures even when some games succeeded —
+      // a partial-failure sync should never log a clean `ok` here while the
+      // step log is full of error rows (#68). (The user-facing terminal stage
+      // below stays `complete` for partial success so the sync still finishes.)
       step: 'sync-end',
-      status: errors.length > 0 && gamesProcessed === 0 ? 'error' : 'ok',
+      status: errors.length > 0 ? 'error' : 'ok',
       details: {
         gamesProcessed,
+        gamesFailed,
         cardsCreated,
         gamesTotal: pgns.length,
         errorCount: errors.length,


### PR DESCRIPTION
## What changed and why

When the app downloads and reviews your Chess.com games, a few problems used to slip by silently: a game could be skipped or fail, but the activity log would still show everything as "done" with a green checkmark. That made real failures very hard to notice.

This change makes those situations honest:

- If a game has no playable moves to review (a broken or empty game file), it's now counted as a **failed** game instead of quietly being treated as a success that produced nothing.
- When a game is reviewed but turns up no flashcard-worthy moments, that step is now marked **"skipped"** rather than a green **"ok"** — so the log never overstates what happened.
- Flashcards can no longer be saved without being linked back to the game they came from (previously a glitch could leave "orphan" cards).
- Each sync now reports a **count of games that failed**, and the run's summary line is flagged as an error whenever any game failed — so a sync can't look perfectly clean while failures pile up underneath.

No database changes and no changes to how a normal, healthy sync behaves — this only affects how problems are reported.

## Test plan

- [ ] **Golden path:** Run a normal sync (Sync page → run it) with a Chess.com account that has real games. It should complete as before, create flashcards, and the activity log should show the steps as "ok". The summary should show 0 failed games.
- [ ] **Edge case:** Trigger a sync that includes a broken/empty game. Confirm the run still finishes, the broken game shows up as a failure (not a silent success), and the summary reflects that at least one game failed rather than looking all-clean.

Closes #68