### PR TITLE
Fix brief 'Never synced' flash on the sync page (issue #69)

### DIFF
--- a/__tests__/hooks/use-fetch-json.test.tsx
+++ b/__tests__/hooks/use-fetch-json.test.tsx
@@ -55,6 +55,41 @@ describe('useFetchJson', () => {
     expect(result.current.error?.message).toBe('network down')
   })
 
+  // #69: a 401 during a session-cookie refresh is transient — retry once.
+  it('retries once on a 401 and resolves when the retry succeeds', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(failResponse(401))
+      .mockResolvedValueOnce(okResponse({ n: 7 }))
+    global.fetch = fetchMock
+    const { result } = renderHook(() => useFetchJson('/x', identity))
+    await waitFor(() => expect(result.current.data).toEqual({ n: 7 }))
+    expect(result.current.error).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up and sets error after a second consecutive 401', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(failResponse(401))
+      .mockResolvedValueOnce(failResponse(401))
+    global.fetch = fetchMock
+    const { result } = renderHook(() => useFetchJson('/x', identity))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).not.toBeNull()
+    expect(result.current.data).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry on a non-401 failure', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(failResponse(500))
+    global.fetch = fetchMock
+    const { result } = renderHook(() => useFetchJson('/x', identity))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).not.toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('refetch triggers another request', async () => {
     const fetchMock = jest
       .fn()

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -91,3 +91,24 @@ it('allows unauthenticated access to /api/inngest (Inngest webhook)', async () =
 
   expect(res.status).not.toBe(307)
 })
+
+// #69: API routes guard themselves and return a 401 JSON. The middleware must
+// not redirect them to the HTML login page — during a cookie-refresh race that
+// would hand the client an unparseable login page instead of a clean 401.
+it('does not redirect an unauthenticated /api request to /login', async () => {
+  mockGetUser.mockResolvedValue({ data: { user: null } })
+
+  const req = new NextRequest('http://localhost/api/sync/status')
+  const res = await middleware(req)
+
+  expect(res.status).not.toBe(307)
+})
+
+it('passes an authenticated /api request through', async () => {
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } })
+
+  const req = new NextRequest('http://localhost/api/sync/history')
+  const res = await middleware(req)
+
+  expect(res.status).not.toBe(307)
+})

--- a/hooks/use-fetch-json.ts
+++ b/hooks/use-fetch-json.ts
@@ -9,6 +9,12 @@ export interface FetchResult<T> {
   refetch: () => void
 }
 
+// A 401 right after the session cookie is refreshed is usually transient: a
+// concurrent request rotated the auth cookie and this one briefly raced with
+// it. The refreshed cookie lands within a moment, so a single short-delayed
+// retry recovers cleanly instead of flashing an unauthenticated state (#69).
+const UNAUTH_RETRY_DELAY_MS = 300
+
 export function useFetchJson<T>(
   url: string,
   validate: (raw: unknown) => T | null,
@@ -23,11 +29,20 @@ export function useFetchJson<T>(
     setLoading(true)
     setError(null)
 
-    fetch(url)
-      .then(async (r) => {
+    async function fetchJson(): Promise<unknown> {
+      for (let attempt = 0; ; attempt++) {
+        const r = await fetch(url)
+        if (r.status === 401 && attempt === 0) {
+          await new Promise((resolve) => setTimeout(resolve, UNAUTH_RETRY_DELAY_MS))
+          if (cancelled) return null
+          continue
+        }
         if (!r.ok) throw new Error(`Request failed (${r.status})`)
         return r.json()
-      })
+      }
+    }
+
+    fetchJson()
       .then((raw) => {
         if (cancelled) return
         const parsed = validate(raw)

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,6 +40,17 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
+  // API routes authenticate themselves (each data route returns a 401 JSON via
+  // withAuthedRoute; only /api/health and /api/inngest are intentionally open).
+  // Never redirect an /api request to the HTML login page: during a session
+  // cookie refresh, concurrent requests can momentarily appear unauthenticated,
+  // and a redirect would hand the client a login page it can't parse — which
+  // surfaces as a brief "Never synced" / empty state (#69). Return the response
+  // carrying any refreshed cookies and let the route decide.
+  if (pathname.startsWith('/api/')) {
+    return response
+  }
+
   // Logged-in users visiting the landing or auth pages go straight to the app
   if (user && (pathname === '/' || pathname === '/login' || pathname === '/signup')) {
     const url = request.nextUrl.clone()


### PR DESCRIPTION
## What changed and why

Sometimes when you opened the **Sync** page, it would flash "Never synced" with an empty history for a moment before the real data appeared. This was a timing glitch in the login system, not lost data.

When the page loads, your browser quietly fires a few requests at the same time — the page plus two background calls for "latest sync status" and "sync history." They all carry the same login cookie. The login system swaps that cookie for a fresh one every so often, and the old one stops working the instant it's swapped. When several requests land together right at swap time, one does the swap and the others are briefly holding the just-expired cookie, so they come back as "not logged in" — and the page reads that as "nothing here."

Two small, contained fixes:
- **The gatekeeper no longer sends background data calls to the login page.** Each data endpoint already checks login on its own and returns a clean "not logged in" answer, so during a cookie swap the page now gets a recognizable signal instead of a login web page it can't read. (Only the public health check and the Inngest webhook are open, and that's intentional.)
- **The page's data loader now tries once more after a brief pause** if a call comes back "not logged in." By then the refreshed cookie has landed, so the second try succeeds and the correct data appears — no flash.

No database changes, and a normal healthy page load behaves exactly as before.

## Test plan

- [ ] **Golden path:** Open the Sync page normally. It should show your real sync status and history with no flash of "Never synced."
- [ ] **Edge case:** Leave a tab open for a while (long enough that the login cookie needs refreshing), then reload the Sync page. It should load straight into the correct status/history without briefly showing an empty/"Never synced" state. (Reloading repeatedly should never get "stuck" on the empty state.)

Closes #69