### PR TITLE
Close the audit timeline for failed syncs (issue #70)

### DIFF
--- a/__tests__/lib/inngest-terminal-state.test.ts
+++ b/__tests__/lib/inngest-terminal-state.test.ts
@@ -34,4 +34,69 @@ describe('markSyncFailed', () => {
     const stored = updated.sync_log![0].values.error as string
     expect(stored.length).toBeLessThanOrEqual(2000)
   })
+
+  // #70: a failed run should close its audit timeline with a terminal step row,
+  // mirroring the `sync-end` row a successful run emits.
+  it('writes a terminal sync-failed step row to the audit timeline', async () => {
+    const { db, inserted } = makeMockDb({
+      sync_log: [{ id: SYNC_ID, stage: 'analyzing' }],
+      sync_step_log: [],
+    })
+
+    await markSyncFailed(db, SYNC_ID, 'Sync timed out after retries')
+
+    const steps = inserted.sync_step_log ?? []
+    expect(steps).toHaveLength(1)
+    expect(steps[0]).toMatchObject({
+      sync_log_id: SYNC_ID,
+      step: 'sync-failed',
+      status: 'error',
+      error: 'Sync timed out after retries',
+    })
+  })
+
+  it('truncates the terminal step row error to match the sync_log row', async () => {
+    const { db, inserted } = makeMockDb({
+      sync_log: [{ id: SYNC_ID, stage: 'analyzing' }],
+      sync_step_log: [],
+    })
+
+    await markSyncFailed(db, SYNC_ID, 'x'.repeat(5000))
+
+    const stored = (inserted.sync_step_log ?? [])[0].error as string
+    expect(stored.length).toBeLessThanOrEqual(2000)
+  })
+
+  it('does not write a second terminal row when one already exists (idempotent across retries)', async () => {
+    const { db, inserted } = makeMockDb({
+      sync_log: [{ id: SYNC_ID, stage: 'error' }],
+      sync_step_log: [
+        { id: 'existing-1', sync_log_id: SYNC_ID, step: 'sync-failed', status: 'error' },
+      ],
+    })
+
+    await markSyncFailed(db, SYNC_ID, 'Sync timed out after retries')
+
+    expect(inserted.sync_step_log ?? []).toHaveLength(0)
+  })
+
+  it('still records the failure on sync_log even if the step-row write fails', async () => {
+    const { db, updated } = makeMockDb({
+      sync_log: [{ id: SYNC_ID, stage: 'analyzing' }],
+      sync_step_log: [],
+    })
+    // Make the audit-row insert blow up; the sync_log update must still stand.
+    const realFrom = db.from.bind(db)
+    ;(db as unknown as { from: (t: string) => unknown }).from = (table: string) => {
+      if (table === 'sync_step_log') {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ limit: () => { throw new Error('audit down') } }) }) }),
+        }
+      }
+      return realFrom(table)
+    }
+
+    await expect(markSyncFailed(db, SYNC_ID, 'boom')).resolves.toBeUndefined()
+    expect(updated.sync_log![0].values.stage).toBe('error')
+  })
 })

--- a/lib/inngest/terminal-state.ts
+++ b/lib/inngest/terminal-state.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { makeSupabaseStepLogger } from '@/lib/sync-step-logger'
 
 const MAX_ERROR_LEN = 2000
 
@@ -16,4 +17,41 @@ export async function markSyncFailed(
       error: truncated,
     })
     .eq('id', syncLogId)
+
+  await writeTerminalStepRow(db, syncLogId, truncated)
+}
+
+/**
+ * Close a failed run's audit timeline with a terminal `sync-failed` step row,
+ * mirroring the `sync-end` row a successful run emits. Without this, a run that
+ * crashes or times out before runSync can write its own `sync-end` leaves the
+ * `/sync/<id>` timeline stopping abruptly after the last per-game step (#70).
+ *
+ * - Idempotent: markSyncFailed can run once per Inngest retry and again from
+ *   the onFailure handler, but the timeline should carry a single terminal row.
+ * - Best-effort: an audit-log write hiccup must never throw out of the terminal
+ *   handler and mask the real failure already recorded on `sync_log`.
+ */
+async function writeTerminalStepRow(
+  db: SupabaseClient,
+  syncLogId: string,
+  error: string,
+): Promise<void> {
+  try {
+    const { data: existing } = await db
+      .from('sync_step_log')
+      .select('id')
+      .eq('sync_log_id', syncLogId)
+      .eq('step', 'sync-failed')
+      .limit(1)
+    if (existing && existing.length > 0) return
+
+    await makeSupabaseStepLogger(db, syncLogId)({
+      step: 'sync-failed',
+      status: 'error',
+      error,
+    })
+  } catch {
+    // Swallow — sync_log.error is the source of truth for the failure.
+  }
 }

--- a/lib/sync-orchestrator.ts
+++ b/lib/sync-orchestrator.ts
@@ -40,6 +40,10 @@ export type SyncStep =
   | 'fetch-archives-end'
   | 'sync-start'
   | 'sync-end'
+  // Terminal row written by markSyncFailed when a run crashes/times out before
+  // runSync can emit its own `sync-end`, so the audit timeline closes cleanly
+  // for failed runs too (#70).
+  | 'sync-failed'
   | 'fetch'
   | 'parse-headers'
   | 'parse-positions'


### PR DESCRIPTION
## What changed and why

On the sync detail page (`/sync/<id>`) there's a step-by-step timeline of everything a sync did. A **successful** sync already ends that timeline with a clear closing line ("sync-end"). A sync that **fails** — crashes or times out — didn't get one: the timeline just stopped after the last game it managed to process, even though the failure was recorded on the summary record. That made failed runs look like they were cut off mid-thought.

This adds a matching closing line ("sync-failed") to the timeline whenever a run fails, so successful and failed runs both end cleanly and the timeline is self-explanatory without cross-checking the summary.

Two safeguards built in:
- **No duplicates:** a failed sync can be marked failed more than once (once per automatic retry, and again at the very end). The closing line is only written once, so the timeline shows a single clean ending.
- **Never makes things worse:** if writing that closing line ever hiccups, it's quietly skipped — the actual failure is still recorded on the summary record as before.

No database changes; this only adds the missing timeline row on failures.

## Test plan

- [ ] **Golden path (success unchanged):** Run a normal sync, open its detail page, and confirm the timeline still ends with the "sync-end" line as before.
- [ ] **Edge case (failure):** Trigger a sync that fails (e.g. a run that errors out or times out). Open its detail page and confirm the timeline now ends with a red "sync-failed" line carrying the error, instead of stopping abruptly. Reloading/retried failures should still show only one such line.

Closes #70