### PR TITLE
Move onboarding's account-link step onto a server route (issue #48)

### DIFF
--- a/__tests__/api/chess-account.test.ts
+++ b/__tests__/api/chess-account.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+
+import { PUT } from '@/app/api/chess-account/route'
+import type { PlayerCheck } from '@/app/api/chess-account/route'
+import { makeMockDb } from '@/__tests__/helpers/mock-db'
+
+const USER = '00000000-0000-0000-0000-000000000001'
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/chess-account', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const found = async (): Promise<PlayerCheck> => 'found'
+
+describe('PUT /api/chess-account', () => {
+  it('returns 401 when there is no authenticated user', async () => {
+    const { db } = makeMockDb({ users: [{ id: USER }] })
+
+    const response = await PUT(makeRequest({ username: 'hikaru' }), {
+      db,
+      authFn: async () => null,
+      checkPlayer: found,
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it.each([
+    ['empty', { username: '   ' }],
+    ['missing', {}],
+    ['illegal characters', { username: 'bad name!' }],
+    ['wrong type', { username: 123 }],
+  ])('rejects an invalid username (%s) with 400 and writes nothing', async (_label, body) => {
+    const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+    const response = await PUT(makeRequest(body), {
+      db,
+      authFn: async () => ({ id: USER }),
+      checkPlayer: found,
+    })
+
+    expect(response.status).toBe(400)
+    expect(updated.users ?? []).toHaveLength(0)
+  })
+
+  it('returns 404 and writes nothing when the player is not found on Chess.com', async () => {
+    const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+    const response = await PUT(makeRequest({ username: 'definitely-not-real' }), {
+      db,
+      authFn: async () => ({ id: USER }),
+      checkPlayer: async () => 'not_found',
+    })
+
+    expect(response.status).toBe(404)
+    expect(updated.users ?? []).toHaveLength(0)
+  })
+
+  it('returns 502 when Chess.com cannot be reached to verify', async () => {
+    const { db, updated } = makeMockDb({ users: [{ id: USER }] })
+
+    const response = await PUT(makeRequest({ username: 'hikaru' }), {
+      db,
+      authFn: async () => ({ id: USER }),
+      checkPlayer: async () => 'unreachable',
+    })
+
+    expect(response.status).toBe(502)
+    expect(updated.users ?? []).toHaveLength(0)
+  })
+
+  it('saves the username on the user row and echoes it back on success', async () => {
+    const { db, updated } = makeMockDb({ users: [{ id: USER, chess_com_username: null }] })
+
+    const response = await PUT(makeRequest({ username: '  Hikaru  ' }), {
+      db,
+      authFn: async () => ({ id: USER }),
+      checkPlayer: found,
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true, username: 'Hikaru' })
+
+    const write = updated.users?.[0]
+    expect(write?.values).toEqual({ chess_com_username: 'Hikaru' })
+    expect(write?.filters).toEqual([{ op: 'eq', col: 'id', val: USER }])
+  })
+
+  it('returns 400 on malformed JSON', async () => {
+    const { db } = makeMockDb({ users: [{ id: USER }] })
+    const badReq = new Request('http://localhost/api/chess-account', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not json',
+    })
+
+    const response = await PUT(badReq, {
+      db,
+      authFn: async () => ({ id: USER }),
+      checkPlayer: found,
+    })
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/__tests__/lib/chess-com/check-player.test.ts
+++ b/__tests__/lib/chess-com/check-player.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { checkPlayerExists, ChessComApiError } from '../../../lib/chess-com/client'
+
+function fakeResponse(status: number) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => ({}),
+  }
+}
+
+function mockFetch(status: number) {
+  global.fetch = jest.fn().mockResolvedValue(fakeResponse(status)) as unknown as typeof fetch
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('checkPlayerExists', () => {
+  it('returns true on a 200 and queries the lowercased handle', async () => {
+    mockFetch(200)
+
+    await expect(checkPlayerExists('Hikaru')).resolves.toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.chess.com/pub/player/hikaru',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    )
+  })
+
+  it('returns false on a 404 (player does not exist)', async () => {
+    mockFetch(404)
+
+    await expect(checkPlayerExists('nope')).resolves.toBe(false)
+  })
+
+  it('throws ChessComApiError on other failures (e.g. 500)', async () => {
+    mockFetch(500)
+
+    await expect(checkPlayerExists('hikaru')).rejects.toThrow(ChessComApiError)
+  })
+})

--- a/app/api/chess-account/route.ts
+++ b/app/api/chess-account/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createClient, getSessionUser } from '@/lib/supabase/server'
+import { checkPlayerExists } from '@/lib/chess-com/client'
+
+/** Outcome of the server-side Chess.com existence check. */
+export type PlayerCheck = 'found' | 'not_found' | 'unreachable'
+
+interface ChessAccountDeps {
+  db?: SupabaseClient
+  authFn?: () => Promise<{ id: string } | null>
+  /** Injectable so tests never hit the network. */
+  checkPlayer?: (username: string) => Promise<PlayerCheck>
+}
+
+type NextRouteContext = { params: Promise<Record<string, string | string[] | undefined>> }
+
+// Chess.com handles are letters/digits/underscore/hyphen. The real validation
+// is the existence check below; this just keeps junk out of the proxied call.
+const USERNAME_RE = /^[A-Za-z0-9_-]{1,50}$/
+
+async function defaultCheckPlayer(username: string): Promise<PlayerCheck> {
+  try {
+    return (await checkPlayerExists(username)) ? 'found' : 'not_found'
+  } catch {
+    // Network error, rate limit, or 5xx — we couldn't confirm either way.
+    return 'unreachable'
+  }
+}
+
+/**
+ * Link (or update) the signed-in user's Chess.com account.
+ *
+ * Replaces the onboarding flow's browser-side Supabase upsert + direct
+ * chess.com fetch (#48): auth runs through the session cookie, the existence
+ * check is proxied server-side, and the write goes through the service-bound
+ * client like every other route.
+ */
+export async function PUT(req: Request, deps: ChessAccountDeps): Promise<NextResponse>
+export async function PUT(req: Request, ctx: NextRouteContext): Promise<NextResponse>
+export async function PUT(req: Request, deps: ChessAccountDeps | NextRouteContext): Promise<NextResponse> {
+  const actualDeps: ChessAccountDeps = (deps ?? {}) as ChessAccountDeps
+  const authFn = actualDeps.authFn ?? getSessionUser
+  const user = await authFn()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const raw = (body ?? {}) as Record<string, unknown>
+  const username = typeof raw.username === 'string' ? raw.username.trim() : ''
+  if (!USERNAME_RE.test(username)) {
+    return NextResponse.json(
+      { error: 'Enter a valid Chess.com username (letters, numbers, underscore or hyphen).' },
+      { status: 400 },
+    )
+  }
+
+  const checkPlayer = actualDeps.checkPlayer ?? defaultCheckPlayer
+  const check = await checkPlayer(username)
+  if (check === 'not_found') {
+    return NextResponse.json(
+      { error: 'Username not found on Chess.com. Check the spelling and try again.' },
+      { status: 404 },
+    )
+  }
+  if (check === 'unreachable') {
+    return NextResponse.json(
+      { error: 'Could not reach Chess.com to verify that username. Please try again.' },
+      { status: 502 },
+    )
+  }
+
+  // The users row is auto-created on signup (migration 004), so a plain update
+  // is enough — no need to carry the email for an insert.
+  const db = actualDeps.db ?? (await createClient())
+  const { error } = await db
+    .from('users')
+    .update({ chess_com_username: username })
+    .eq('id', user.id)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, username })
+}

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Logo, Button, Field, Input } from '@/components/ui'
-import { createClient } from '@/lib/supabase/client'
 import { pollSyncUntilTerminal } from '@/lib/poll-sync-progress'
 
 const STAGE_LABEL: Record<string, string> = {
@@ -99,17 +98,12 @@ function LinkStep({ onNext }: { onNext: (username: string) => void }) {
   const [verified, setVerified] = useState(false)
   const [verifyError, setVerifyError] = useState<string | null>(null)
 
-  // Pre-fill from DB if already set
+  // Pre-fill from the existing profile if a username is already linked.
   useEffect(() => {
-    const supabase = createClient()
-    supabase.auth.getUser().then(async ({ data }) => {
-      if (!data.user) return
-      const { data: userData } = await supabase
-        .from('users')
-        .select('chess_com_username')
-        .eq('id', data.user.id)
-        .single()
-      if (userData?.chess_com_username) setUsername(userData.chess_com_username)
+    fetch('/api/me').then(async (r) => {
+      if (!r.ok) return
+      const data = await r.json().catch(() => null)
+      if (data?.username) setUsername(data.username)
     })
   }, [])
 
@@ -118,30 +112,22 @@ function LinkStep({ onNext }: { onNext: (username: string) => void }) {
     setVerifying(true)
     setVerifyError(null)
     try {
-      const res = await fetch(`https://api.chess.com/pub/player/${username.trim().toLowerCase()}`)
+      // One server-side call validates the handle, checks it exists on
+      // Chess.com, and saves it — no browser-to-Supabase or browser-to-chess.com
+      // traffic (#48).
+      const res = await fetch('/api/chess-account', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: username.trim() }),
+      })
       if (res.ok) {
-        // Save to DB
-        const supabase = createClient()
-        const { data: { user } } = await supabase.auth.getUser()
-        if (!user) {
-          setVerifyError('Not signed in. Please log in again and retry.')
-          setVerifying(false)
-          return
-        }
-        const { error: saveError } = await supabase
-          .from('users')
-          .upsert({ id: user.id, email: user.email!, chess_com_username: username.trim() })
-        if (saveError) {
-          setVerifyError(`Could not save username: ${saveError.message}`)
-          setVerifying(false)
-          return
-        }
         setVerified(true)
       } else {
-        setVerifyError('Username not found on Chess.com. Check the spelling and try again.')
+        const body = await res.json().catch(() => ({}))
+        setVerifyError(body.error ?? `Could not verify username (${res.status}).`)
       }
     } catch {
-      setVerifyError('Could not reach Chess.com. Check your connection.')
+      setVerifyError('Network error — please try again.')
     }
     setVerifying(false)
   }

--- a/lib/chess-com/client.ts
+++ b/lib/chess-com/client.ts
@@ -80,6 +80,24 @@ async function fetchWithRetry(url: string, init: RequestInit): Promise<Response>
   }
 }
 
+/**
+ * Check whether a Chess.com player profile exists. Hits the public player
+ * endpoint server-side so the browser never talks to chess.com directly
+ * (onboarding's account-link step, #48). Returns true on 200, false on 404;
+ * any other status (rate limit, 5xx, etc.) throws ChessComApiError so the
+ * caller can distinguish "not found" from "couldn't check".
+ */
+export async function checkPlayerExists(username: string): Promise<boolean> {
+  const url = `${CHESS_COM_BASE}/${username.toLowerCase()}`
+  const response = await fetchWithRetry(url, { headers: chessComHeaders() })
+
+  if (response.status === 404) return false
+  if (!response.ok) {
+    throw new ChessComApiError(`Chess.com API error: ${response.status}`, response.status)
+  }
+  return true
+}
+
 export async function fetchArchiveList(username: string): Promise<string[]> {
   // Chess.com's public API is case-sensitive — 'Catalyst030119' returns 301,
   // 'catalyst030119' returns 200. Normalize at the boundary.


### PR DESCRIPTION
## What changed and why

During onboarding, the "Link your Chess.com account" step used to reach out to both the login database and Chess.com **directly from the browser**. Every other part of the app now goes through a server endpoint instead, which keeps the login checks and data writes consistent and handled in one place. This brings that last step in line.

What I did:
- **Added a server endpoint** that takes the username you type, confirms it exists on Chess.com (the app's server does that check now, not your browser), and saves it to your account.
- **Rewired the onboarding step** to use that endpoint, plus the existing "about me" endpoint to pre-fill a username you've already linked.
- The result: the account-link step no longer talks to the database or Chess.com from the browser at all.

No visual changes to onboarding, and no database changes. The other onboarding steps (import games, set cadence) already went through server endpoints and were left as-is.

## Test plan

- [ ] **Golden path:** Start onboarding, go to the "Link account" step, type a real Chess.com username, and click Verify. It should show "✓ Verified" and let you continue. Finishing onboarding should land you on the dashboard with games importing.
- [ ] **Wrong username:** Type a username that doesn't exist on Chess.com and click Verify. It should show a clear "Username not found" message and not let you continue.
- [ ] **Already linked:** If you've already linked a username, returning to this step should pre-fill it.

Closes #48